### PR TITLE
fix🐛: fix section title on runing `rustc` command

### DIFF
--- a/docs/basic/build-dan-run-program-rust.md
+++ b/docs/basic/build-dan-run-program-rust.md
@@ -67,7 +67,7 @@ Kemudian *compile* lalu jalankan file *executable*-nya, hasilnya adalah sama sep
     ./hello
     ```
 
-- MacOS, Linux, Unix, WSL
+- Windows
 
     ```bash
     rustc hello.rs


### PR DESCRIPTION
Fix Section title on section **A.2.3.**
Should be "Windows" not "MacOS, Linux, Unix, WSL"