### PR TITLE
fix: typo on sub-bab `A.1. Program Pertama → Hello Rust` 

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -17,4 +17,5 @@ E-book ini di-inisialisasi oleh Noval Agung Prayogo.
 Berikut merupakan hall of fame kontributor yang sudah berbaik hati menyisihkan waktunya untuk membantu pengembangan e-book ini.
 
 1. [I Putu Saputrayana](https://github.com/iyansr)
-1. ... anda :-)
+2. [Theis Andatu](https://github.com/antheiz)
+3. ... anda :-)

--- a/docs/basic/hello-rust.md
+++ b/docs/basic/hello-rust.md
@@ -65,7 +65,7 @@ fn main() {
 
 ### ◉ Notasi pendefinisian fungsi
 
-Pembuatan fungsi di Rust menggunakan keyword fn dengan notasi penulisan sebagai berikut, contoh:
+Pembuatan fungsi di rust menggunakan keyword `fn` dengan notasi penulisan sebagai berikut, contoh:
 
 ```bash
 fn namaFungsi() {

--- a/docs/basic/hello-rust.md
+++ b/docs/basic/hello-rust.md
@@ -65,7 +65,7 @@ fn main() {
 
 ### ◉ Notasi pendefinisian fungsi
 
-Pembuatan fungsi di rusat menggunakan keyword `fn` dengan notasi penulisan sebagai berikut, contoh:
+Pembuatan fungsi di Rust menggunakan keyword fn dengan notasi penulisan sebagai berikut, contoh:
 
 ```bash
 fn namaFungsi() {
@@ -104,7 +104,7 @@ Agar pembaca tidak bertambah bingung, setidaknya untuk sekarang pada chapter awa
 println!("Hello, world!");
 ```
 
-Macro `println` digunakan digunakan untuk menampilkan string atau pesan ke console output (`stdout`) dan diikuti oleh baris baru (newline/enter). Agar lebih jelas jalankan kode berikut:
+Macro `println` digunakan untuk menampilkan string atau pesan ke console output (`stdout`) dan diikuti oleh baris baru (newline/enter). Agar lebih jelas jalankan kode berikut:
 
 ```rust title="src/main.rs"
 fn main() {


### PR DESCRIPTION
1. Typo penulisan rust sebelumnya **rusat** yang seharusnya **rust**
2. Pada bagian macro println terjadi duplikasi kata **digunakan**.
