### PR TITLE
fix: typo

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,6 +25,7 @@ Berikut merupakan hall of fame kontributor yang sudah berbaik hati menyisihkan w
 
 1. [Acep Saepudin](https://github.com/acepsaepudin)
 1. [Afifurrohman](https://github.com/afifurrohman-id)
+1. [ardiantovn](https://github.com/ardiantovn)
 1. [Fal](https://github.com/d0tf)
 1. [Fredianto](https://github.com/nferdazel)
 1. [I Putu Saputrayana](https://github.com/iyansr)

--- a/docs/basic/array.md
+++ b/docs/basic/array.md
@@ -6,7 +6,7 @@ description: Belajar array pada rust. Contoh penerapan array, iterasi array, dan
 keywords: [rust, belajar rust, array rust, slice rust]
 ---
 
-Pada chapter awal kita sudah mempelajari tipe data primitif jenis scalas. Selain *scalar types* ada juga tipe data primitif lainnya yaitu **compound types**. Compound types sendiri adalah jenis tipe data kolektif yang isinya banyak data. Kesemua data tersebut memiliki tipe data yang sama dan di-group menjadi satu.
+Pada chapter awal kita sudah mempelajari tipe data primitif jenis scalar. Selain *scalar types* ada juga tipe data primitif lainnya yaitu **compound types**. Compound types sendiri adalah jenis tipe data kolektif yang isinya banyak data. Kesemua data tersebut memiliki tipe data yang sama dan di-group menjadi satu.
 
 Array adalah salah satu tipe data compound yang tersedia di Rust, dan pada chapter ini kita akan mempelajarinya.
 
@@ -49,7 +49,7 @@ Selanjutnya mari kita bahas dengan detail contoh di atas.
 
 Variabel `numbers` dideklarasikan sebagai array *mutable* dengan metode deklarasi type inference, yang tipe datanya didapat langsung dari nilai.
 
-Value dari `numbers` adalah `[24, 12, 32, 7]`, yang dimana artinya sebuah array dengan size 4, bertipe numerik, dengan isi `24`, `12`, `32`, `7`.
+Value dari `numbers` adalah `[24, 12, 32, 7]`, yang di mana artinya sebuah array dengan size 4, bertipe numerik, dengan isi `24`, `12`, `32`, `7`.
 
 Sintaks `[24, 12, 32, 7]` adalah salah satu cara menulis literal array. Tulis saja data yang diinginkan dengan separator `,` dan diapit tanda kurung siku `[ ]`.
 
@@ -138,7 +138,7 @@ Jika kawan-kawan menggunakan ekstensi VSCode `rust-analyzer`, akan terlihat info
 
 ## A.13.3. Macam-macam deklarasi array
 
-Array lebih mudah dideklarasikan dengan metode *type inference*. Namun tak menutup kemungkinan ada kebutuhan dimana array harus dideklarasikan dengan menuliskan tipe datanya secara eksplisit. Berikut adalah macam-macam cara mendeklarasikan array.
+Array lebih mudah dideklarasikan dengan metode *type inference*. Namun tak menutup kemungkinan ada kebutuhan di mana array harus dideklarasikan dengan menuliskan tipe datanya secara eksplisit. Berikut adalah macam-macam cara mendeklarasikan array.
 
 ### ◉ Deklarasi array dengan metode *type inference*
 
@@ -257,7 +257,7 @@ loop {
 }
 ```
 
-Iterasi array menggunakan `while` dan `loop` umumnya kurang praktis jika dibandingkan dengan `for in`. Tapi pastinya ada case dimana `while` dan/atau `loop` akan dibutuhkan.
+Iterasi array menggunakan `while` dan `loop` umumnya kurang praktis jika dibandingkan dengan `for in`. Tapi pastinya ada case di mana `while` dan/atau `loop` akan dibutuhkan.
 
 ## A.13.7. Iterasi array menggunakan `for in` dan *tuple*
 
@@ -277,7 +277,7 @@ for (i, name) in names.iter().enumerate() {
 
 Variabel `names` yang notabene bertipe data `[&str; 4]` perlu dikonversi ke tipe `Iterator` terlebih dahulu caranya lewat pemanggilan method `.iter()`. Kemudian dari tipe tersebut perlu dikonversi lagi ke tipe `Enumerate` dengan cara memanggil method `.enumerate()`.
 
-Setelah mendapatkan objek bertipe `Enumerate`, keyword `for in` digunakan untuk menampung tiap elemen array dalam bentuk *tuple* `(i, name)`. Variabel `i` disitu berisi counter iterasi, dan `name` adalah value-nya.
+Setelah mendapatkan objek bertipe `Enumerate`, keyword `for in` digunakan untuk menampung tiap elemen array dalam bentuk *tuple* `(i, name)`. Variabel `i` di situ berisi counter iterasi, dan `name` adalah value-nya.
 
 > - Lebih jelasnya mengenai traits dibahas pada chapter [Traits](/basic/traits)
 > - Lebih jelasnya mengenai `Enumerate` dibahas pada chapter [Trait ➜ Iterator](/basic/trait-iterator)
@@ -311,7 +311,7 @@ for sub_arr in data_arr {
 // spinach, jalapeno,
 ```
 
-Variabel `data_arr` pada contoh di atas bertipe data`[[&str; 2] 3]`, yang artinya adalah sebuah array dengan size 3, dengan isi elemen adalah juga array dengan size 2. Selalu ingat bahwa size array adalah fixed.
+Variabel `data_arr` pada contoh di atas bertipe data`[[&str; 2]; 3]`, yang artinya adalah sebuah array dengan size 3, dengan isi elemen adalah juga array dengan size 2. Selalu ingat bahwa size array adalah fixed.
 
 ---
 

--- a/docs/basic/array.md
+++ b/docs/basic/array.md
@@ -49,7 +49,7 @@ Selanjutnya mari kita bahas dengan detail contoh di atas.
 
 Variabel `numbers` dideklarasikan sebagai array *mutable* dengan metode deklarasi type inference, yang tipe datanya didapat langsung dari nilai.
 
-Value dari `numbers` adalah `[24, 12, 32, 7]`, yang di mana artinya sebuah array dengan size 4, bertipe numerik, dengan isi `24`, `12`, `32`, `7`.
+Value dari `numbers` adalah `[24, 12, 32, 7]`, yang mana artinya sebuah array dengan size 4, bertipe numerik, dengan isi `24`, `12`, `32`, `7`.
 
 Sintaks `[24, 12, 32, 7]` adalah salah satu cara menulis literal array. Tulis saja data yang diinginkan dengan separator `,` dan diapit tanda kurung siku `[ ]`.
 

--- a/docs/basic/associated-function.md
+++ b/docs/basic/associated-function.md
@@ -170,13 +170,13 @@ impl NamaStruct {
 
 ## A.24.3. Tipe data `Self`
 
-Tipe data `Self` (perhatikan huruf `S`-nya adalah kapital) merupakan representasi untuk tipe data struct atau trait dimana blok kode `impl` dideklarasikan.
+Tipe data `Self` (perhatikan huruf `S`-nya adalah kapital) merupakan representasi untuk tipe data struct atau trait di mana blok kode `impl` dideklarasikan.
 
 > Tipe data `Self` hanya bisa digunakan dalam blok kode `impl`
 
 Sebagai contoh, pada kode yang sudah dipraktikkan, keyword `impl` diterapkan dalam pembuatan *associated items* untuk struct `LegoSet`. Dalam blok kode tersebut, tipe data `LegoSet` bisa diganti dengan `Self`.
 
-Silakan lihat contoh dibawah ini, ada 4 buah cara deklarasi fungsi `new` yang kesemuanya adalah ekuivalen.
+Silakan lihat contoh di bawah ini, ada 4 buah cara deklarasi fungsi `new` yang kesemuanya adalah ekuivalen.
 
 ```rust
 impl LegoSet {

--- a/docs/basic/attributes.md
+++ b/docs/basic/attributes.md
@@ -75,7 +75,7 @@ fn main() {
 
 ![Attribute](img/attribute-1.png)
 
-Kode di atas menghasilkan error karena enum `Superhero` tidak mengadopsi trait `PartialEq` yang di mana trait ini diperlukan dalam seleksi kondisi menggunakan keyword `if` dan operator `==`.
+Kode di atas menghasilkan error karena enum `Superhero` tidak mengadopsi trait `PartialEq` yang mana trait ini diperlukan dalam seleksi kondisi menggunakan keyword `if` dan operator `==`.
 
 Cara mengatasi error tersebut adalah dengan mengimplementasikan trait `PartialEq` secara eksplisit. Sekarang coba tambahkan kode berikut pada deklarasi enum `Superhero`, maka error akan hilang.
 

--- a/docs/basic/attributes.md
+++ b/docs/basic/attributes.md
@@ -15,7 +15,7 @@ Attribute dikategorikan menjadi 2:
 - Outer attributes
 - Inner attributes
 
-Keduanya memiliki kegunaan yang sama, pembedanya adalah posisi dimana attribute harus dituliskan.
+Keduanya memiliki kegunaan yang sama, pembedanya adalah posisi di mana attribute harus dituliskan.
 
 Outer attribute dituliskan tepat sebelum target (crate, module, module item, atau lainnya) dengan notasi penulisan seperti berikut:
 
@@ -35,7 +35,7 @@ struct LegoSet {
 }
 ```
 
-Sedikit berbeda dengan inner attribute, penulisannya berada didalam target (crate, module, module item, atau lainnya). Notasi penulisannya:
+Sedikit berbeda dengan inner attribute, penulisannya berada di dalam target (crate, module, module item, atau lainnya). Notasi penulisannya:
 
 - `#![attribute = "value"]`
 - `#![attribute(key = "value")]`
@@ -75,7 +75,7 @@ fn main() {
 
 ![Attribute](img/attribute-1.png)
 
-Kode di atas menghasilkan error karena enum `Superhero` tidak mengadopsi trait `PartialEq` yang dimana trait ini diperlukan dalam seleksi kondisi menggunakan keyword `if` dan operator `==`.
+Kode di atas menghasilkan error karena enum `Superhero` tidak mengadopsi trait `PartialEq` yang di mana trait ini diperlukan dalam seleksi kondisi menggunakan keyword `if` dan operator `==`.
 
 Cara mengatasi error tersebut adalah dengan mengimplementasikan trait `PartialEq` secara eksplisit. Sekarang coba tambahkan kode berikut pada deklarasi enum `Superhero`, maka error akan hilang.
 
@@ -206,11 +206,11 @@ fn main() {
 }
 ```
 
-Ada beberapa key yang tersedia pada attribute `cfg`, diantaranya:
+Ada beberapa key yang tersedia pada attribute `cfg`, di antaranya:
 
 ### ◉ Configuration `target_os`
 
-Digunakan untuk menandai bahwa item atau statement dibawah definisi attribute ini dikhususkan untuk sistem operasi tertentu.
+Digunakan untuk menandai bahwa item atau statement di bawah definisi attribute ini dikhususkan untuk sistem operasi tertentu.
 
 ```rust
 #[cfg(target_os = "value")]
@@ -230,7 +230,7 @@ Opsi value yang tersedia:
 
 ### ◉ Configuration `target_arch`
 
-Digunakan untuk menandai bahwa item atau statement dibawah definisi attribute ini dikhususkan untuk arsitektur CPU tertentu.
+Digunakan untuk menandai bahwa item atau statement di bawah definisi attribute ini dikhususkan untuk arsitektur CPU tertentu.
 
 ```rust
 #[cfg(target_arch = "value")]
@@ -301,10 +301,10 @@ Ada beberapa attribute *key* yang bisa digunakan untuk override *lint* warning:
 
 - `#[deny(lint_rule)]` atau `#[forbid(lint_rule)]` untuk melarang suatu *lint rule* yang *default*-nya adalah diperbolehkan.<br />List `lint_rule` bisa dilihat di https://doc.rust-lang.org/rustc/lints/listing/deny-by-default.html.
 
-Selain 3 attribute di atas, ada juga beberapa attribute lainnya untuk keperluan *diagnostic*, diantaranya:
+Selain 3 attribute di atas, ada juga beberapa attribute lainnya untuk keperluan *diagnostic*, di antaranya:
 
-- `#[deprecated]` digunakan untuk menandai bahwa kode dibawahnya adalah *deprecated*.
-- `#[must_use]` digunakan untuk mendandai bahwa kode dibawahnya harus digunakan, jika tidak maka akan muncul error.
+- `#[deprecated]` digunakan untuk menandai bahwa kode di bawahnya adalah *deprecated*.
+- `#[must_use]` digunakan untuk mendandai bahwa kode di bawahnya harus digunakan, jika tidak maka akan muncul error.
 
 ## A.49.5. Attribute *type system*
 
@@ -356,7 +356,7 @@ fn main() {
 
 Sayangnya dalam penggunaan attribute `non_exhaustive` ini, efeknya **hanya bisa dirasakan jika digunakan pada enum atau struct yang berbeda crate**.
 
-Pada contoh di atas, tempat dimana enum dideklarasikan dan digunakan adalah masih dalam satu crate yang sama, jadi kode tetap menghasilkan error.
+Pada contoh di atas, tempat di mana enum dideklarasikan dan digunakan adalah masih dalam satu crate yang sama, jadi kode tetap menghasilkan error.
 
 > Attribute `non_exhaustive` ini jika digunakan pada struct efeknya saat deklarasi variabel boleh tidak menuliskan value property.
 

--- a/docs/basic/basic-memory-management.md
+++ b/docs/basic/basic-memory-management.md
@@ -32,7 +32,7 @@ Dalam bahasa yang menerapkan ARC, programmer dianjurkan untuk perhatian dan bija
 
 ### ◉ Manual memory management
 
-Manual memory management berarti programmer dibebani secara penuh dalam hal manajemen memori, mengharuskan programmer untuk super hati-hati dalam pengalokasian memory, kapan waktunya, dimana alokasinya (apakah *heap* atau *stack*), dan kapan harus melakukan operasi dealokasi memory.
+Manual memory management berarti programmer dibebani secara penuh dalam hal manajemen memori, mengharuskan programmer untuk super hati-hati dalam pengalokasian memory, kapan waktunya, di mana alokasinya (apakah *heap* atau *stack*), dan kapan harus melakukan operasi dealokasi memory.
 
 Metode manajemen memori ini dipakai dalam system programming contohnya bahasa C dan C++.
 
@@ -68,7 +68,7 @@ Hasilnya adalah angka biner berikut:
 
 ## A.32.3. Stack memory
 
-Masih dalam topik manajemen memori, ada dua hal lagi yang sangat penting untuk diketahui, yaitu *stack* dan *heap*. Keduanya adalah bagian dari memory, tempat dimana alokasi dilakukan.
+Masih dalam topik manajemen memori, ada dua hal lagi yang sangat penting untuk diketahui, yaitu *stack* dan *heap*. Keduanya adalah bagian dari memory, tempat di mana alokasi dilakukan.
 
 Data disimpan dalam stack memory dalam bentuk stack. Karakteristik dari stack:
 

--- a/docs/basic/borrowing.md
+++ b/docs/basic/borrowing.md
@@ -237,7 +237,7 @@ Pada kode di atas, mutable borrow terjadi di banyak tempat, yaitu di block fungs
 
 ### ◉ Method `contains` milik `String`
 
-Pada contoh di atas kita menerapkan method baru bernama `contains`. Method ini tersedia untuk tipe data `String`, gunanya adalah untuk mengecek apakah string memiliki substring `x`, dimana `x` adalah argumen pemanggilan method. Method ini mengembalikan nilai `bool`.
+Pada contoh di atas kita menerapkan method baru bernama `contains`. Method ini tersedia untuk tipe data `String`, gunanya adalah untuk mengecek apakah string memiliki substring `x`, di mana `x` adalah argumen pemanggilan method. Method ini mengembalikan nilai `bool`.
 
 Contoh penerapan method `contains`:
 

--- a/docs/basic/borrowing.md
+++ b/docs/basic/borrowing.md
@@ -237,7 +237,7 @@ Pada kode di atas, mutable borrow terjadi di banyak tempat, yaitu di block fungs
 
 ### ◉ Method `contains` milik `String`
 
-Pada contoh di atas kita menerapkan method baru bernama `contains`. Method ini tersedia untuk tipe data `String`, gunanya adalah untuk mengecek apakah string memiliki substring `x`, di mana `x` adalah argumen pemanggilan method. Method ini mengembalikan nilai `bool`.
+Pada contoh di atas kita menerapkan method baru bernama `contains`. Method ini tersedia untuk tipe data `String`, gunanya adalah untuk mengecek apakah string memiliki substring `x`, yang mana `x` sendiri adalah argumen pemanggilan method. Method ini mengembalikan nilai `bool`.
 
 Contoh penerapan method `contains`:
 

--- a/docs/basic/closures.md
+++ b/docs/basic/closures.md
@@ -50,7 +50,7 @@ Perbedaan minor lainnya ada pada notasi penulisan parameter. Pada fungsi tanda `
 
 ### ◉ formatted print `{:.n}`
 
-Notasi penulisan formatted print `{:.n}` digunakan untuk mem-format bilangan desimal dimana `n` adalah jumlah digit setelah tanda `.`.
+Notasi penulisan formatted print `{:.n}` digunakan untuk mem-format bilangan desimal di mana `n` adalah jumlah digit setelah tanda `.`.
 
 Sebagai contoh, variabel `pi` berikut memiliki 0 digit angka dibelakang koma. Untuk menampilkan hanya 4 angka terdepan, bisa gunakan `{:.4}`. Perlu diketahui bahwa angka dibelakang koma yang muncul otomatis dibulatkan.
 

--- a/docs/basic/datetime.md
+++ b/docs/basic/datetime.md
@@ -35,7 +35,7 @@ chrono = "0.4.23"
 
 ### ◉ Tipe `DateTime<Local>`
 
-`DateTime<Local>` (gabungan dari tipe data `chrono::datetime::DateTime` dan generic `chrono::offset::local::Local`) adalah representasi untuk tipe data datetime dengan **timezone offset sesuai dengan dimana program dijalankan**.
+`DateTime<Local>` (gabungan dari tipe data `chrono::datetime::DateTime` dan generic `chrono::offset::local::Local`) adalah representasi untuk tipe data datetime dengan **timezone offset sesuai dengan di mana program dijalankan**.
 
 Sebagai contoh, penulis berlokasi di Jawa Timur, maka ketika ada suatu data bertipe `DateTime<Local>` artinya timezone offset-nya adalah WIB (atau GMT+7).
 
@@ -83,7 +83,7 @@ Statement di atas menghasilkan data datetime dengan isi `2023-03-01 01:02:03 UTC
 
 ### ◉ Via `DateTime::<Utc>::from()`
 
-Cara ini pas digunakan pada situasi dimana kita perlu membuat object datetime dari sebuah [UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time).
+Cara ini pas digunakan pada situasi di mana kita perlu membuat object datetime dari sebuah [UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time).
 
 ```rust
 let sample_date3_in_utc = DateTime::<Utc>::from(UNIX_EPOCH + Duration::from_secs(1524885322));
@@ -166,7 +166,7 @@ Rust memilik caranya sendiri dalam pengelolaan data datetime (yang menurut penul
 
 Tipe data ini sangat berguna dibeberapa case yang kebanyakan adalah perihal konversi data ke bentuk `DateTime`.
 
-Mari kita praktekan dengan contoh agar lebih jelas. Dimisalkan ada keperluan dimana data UNIX time perlu di konversi ke 2 bentuk `DateTime`, dengan timezone offset `Utc` dan `Local`. Pada kasus ini, cara ke-3 dari praktek sebelumnya bisa dilakukan untuk penyelesaian case ini.
+Mari kita praktekan dengan contoh agar lebih jelas. Dimisalkan ada keperluan di mana data UNIX time perlu di konversi ke 2 bentuk `DateTime`, dengan timezone offset `Utc` dan `Local`. Pada kasus ini, cara ke-3 dari praktek sebelumnya bisa dilakukan untuk penyelesaian case ini.
 
 ```rust
 let timestamp: u64 = 1524885322;

--- a/docs/basic/enum.md
+++ b/docs/basic/enum.md
@@ -23,7 +23,7 @@ enum NamaEnum {
 
 `NamaEnum` di atas adalah tipe data custom yang didefinisikan bertipe enum. Sedangkan `NilaiEnum1`, `Nilai2`, dan `NilaiEnumKe3` adalah yang disebut dengan enum value. Dengan itu maka ketiga enum values tersebut tipe datanya adalah sama, yaitu `NamaEnum`.
 
-Mari kita lanjut praktik. Berikut ini adalah definisi konstanta yang menggunakan tipe data string untuk menampung nilai konstan-nya. Lalu dibawahnya ada lagi definisi nilai konstan tetapi menggunakan enum sebagai tipe data yang digunakan.
+Mari kita lanjut praktik. Berikut ini adalah definisi konstanta yang menggunakan tipe data string untuk menampung nilai konstan-nya. Lalu di bawahnya ada lagi definisi nilai konstan tetapi menggunakan enum sebagai tipe data yang digunakan.
 
 ```rust
 // definisi konstanta
@@ -238,7 +238,7 @@ fn main() {
 }
 ```
 
-Bisa dilihat ada keunikan dalam penulisan seleksi kondisi `Food::MakananLainnya` dalam blok kode `match`. Disitu ada parameter bernama `m` yang parameter tersebut akan berisi data property jika memang *match* dengan `makanan_favorit`.
+Bisa dilihat ada keunikan dalam penulisan seleksi kondisi `Food::MakananLainnya` dalam blok kode `match`. Di situ ada parameter bernama `m` yang parameter tersebut akan berisi data property jika memang *match* dengan `makanan_favorit`.
 
 Coba jalankan untuk melihat hasilnya:
 

--- a/docs/basic/file-path-directory.md
+++ b/docs/basic/file-path-directory.md
@@ -92,7 +92,7 @@ if Path::new(path).is_relative() {
 
 ## A.52.3. Module `std::fs` (file system)
 
-`std::fs` merupakan module yang disediakan Rust untuk pengolahan file system. Didalamnya berisinya banyak sekali fungsi untuk keperluan seperti pembuatan file, modifikasi konten file, dan lainnya.
+`std::fs` merupakan module yang disediakan Rust untuk pengolahan file system. Di dalamnya berisinya banyak sekali fungsi untuk keperluan seperti pembuatan file, modifikasi konten file, dan lainnya.
 
 Sebagai contoh, untuk membuat suatu directory bisa menggunakan `fs::create_dir`. Isi argument pemanggilan fungsi dengan path dalam bentuk string (atau `std::path::Path` juga boleh).
 
@@ -142,7 +142,7 @@ match res {
 
 Fungsi `fs::write` melakukan penulisan konten pada variabel `content` ke path `path`. Mode penulisannya adalah *overwrite* (bukan *append*), yang artinya konten lama pada filepath akan di-*replace* total dengan konten baru.
 
-Jika file tidak ada pada `path` tujuan, maka otomatis dibuatkan file baru. Namun jika folder/directory dimana file akan dibuat/ditulis tidak ada, maka muncul error.
+Jika file tidak ada pada `path` tujuan, maka otomatis dibuatkan file baru. Namun jika folder/directory di mana file akan dibuat/ditulis tidak ada, maka muncul error.
 
 ### ◉ Menghapus file (`fs::remove_file`)
 

--- a/docs/basic/function.md
+++ b/docs/basic/function.md
@@ -249,7 +249,7 @@ Pada contoh di atas, method `as_str` milik tipe data `String` digunakan untuk me
 
 ## A.17.5. *Conditional return value*
 
-Kapan harus menggunakan keyword `return` dalam penentuan nilai balik dan kapan tidak? Jawabannya mungkin adalah preferensi, tapi di luar itu ada juga case dimana keyword `return` harus digunakan, yaitu pada fungsi yang memiliki nilai balik terkondisi. Contoh:
+Kapan harus menggunakan keyword `return` dalam penentuan nilai balik dan kapan tidak? Jawabannya mungkin adalah preferensi, tapi di luar itu ada juga case di mana keyword `return` harus digunakan, yaitu pada fungsi yang memiliki nilai balik terkondisi. Contoh:
 
 ```rust
 fn get_score_message(score: f32) -> &'static str {
@@ -275,7 +275,7 @@ fn main() {
 
 Teknik penentuan nilai balik tanpa keyword `return` hanya bisa dipergunakan di akhir blok kode, contohnya pada fungsi `get_score_message` statement terakhir blok kode adalah string literal `"your score is below the passing grade"`.
 
-**Jika pada selain akhir blok ada kondisi dimana nilai balik harus ditentukan, maka wajib menggunakan keyword `return`**. Bisa dilihat pada fungsi yang sudah ditulis, `return` statement dalam blok kode seleksi kondisi `if` dipergunakan.
+**Jika pada selain akhir blok ada kondisi di mana nilai balik harus ditentukan, maka wajib menggunakan keyword `return`**. Bisa dilihat pada fungsi yang sudah ditulis, `return` statement dalam blok kode seleksi kondisi `if` dipergunakan.
 
 ## A.17.6. Nilai balik fungsi bertipe string literal `&str`
 

--- a/docs/basic/generics.md
+++ b/docs/basic/generics.md
@@ -20,7 +20,7 @@ fn do_something<T>(arg1: i32, arg2: T) {
 }
 ```
 
-Pada contoh di atas, fungsi `do_something` didefinisikan dengan 2 buah parameter argument dan 1 buah parameter generics. Parameter argument pertama, yaitu `arg1` bertipe `i32`, kemudian diikuti parameter ke-2 bertipe `T` di mana `T` adalah parameter generic fungsi.
+Pada contoh di atas, fungsi `do_something` didefinisikan dengan 2 buah parameter argument dan 1 buah parameter generics. Parameter argument pertama, yaitu `arg1` bertipe `i32`, kemudian diikuti parameter ke-2 bertipe `T` yang mana `T` adalah parameter generic fungsi.
 
 Dalam pemanggilan fungsi tersebut, `T` generics dan tipe data argument `arg2` harus sama. Contoh:
 
@@ -81,7 +81,7 @@ Repot kan? Tapi tenang, tidak usah khawatir, ada soluasi agar tipe `T` bisa dima
 
 ### ◉ Contoh ke-1
 
-Contoh pengaplikasiannya bisa dilihat pada kode berikut. Ada sebuah fungsi bernama `print_x_times` yang tugasnya adalah menampilkan data `T` sejumlah `x` kali, di mana `T` adalah parameter generics.
+Contoh pengaplikasiannya bisa dilihat pada kode berikut. Ada sebuah fungsi bernama `print_x_times` yang tugasnya adalah menampilkan data `T` sejumlah `x` kali, yang mana `T` adalah parameter generics.
 
 ```rust
 fn main() {
@@ -291,7 +291,7 @@ impl<T, U> Point<T, U> {
 }
 ```
 
-Bisa dilihat pada kode di atas, ada method `get_x` untuk mengambil nilai `x`. Nilai baliknya bertipe `T` di mana tipe tersebut juga dipakai sebagai tipe data `x`.
+Bisa dilihat pada kode di atas, ada method `get_x` untuk mengambil nilai `x`. Nilai baliknya bertipe `T` yang tipe tersebut juga dipakai sebagai tipe data `x`.
 
 Kemudian coba gunakan struct `Point` untuk membuat satu atau dua variabel, lalu akses method-nya.
 

--- a/docs/basic/generics.md
+++ b/docs/basic/generics.md
@@ -8,7 +8,7 @@ Chapter ini membahas tentang generics.
 
 Generics sendiri merupakan salah satu fitur yang ada pada beberapa bahasa pemrograman (termasuk Rust), yang digunakan untuk menambahkan fleksibilitas dalam pemanfaatan tipe data pada suatu block kode. Dengan adanya generics, kita bisa menentukan tipe data yang digunakan pada parameter maupun return value sbuah block fungsi, method dan lainnya.
 
-Generics dinotasikan dengan `<T>`. Kita sempat sedikit memanfaatkan generic pada chapter [Vector](/basic/vector) dimana dalam pendefinisian tipe data harus dituliskan juga tipe data item (via generics parameter), contoh `Vec<i32>`, `Vec<&str>`, dll. Kita juga sempat sedikit belajar tentang topik generic pada chapter [Traits](/basic/traits).
+Generics dinotasikan dengan `<T>`. Kita sempat sedikit memanfaatkan generic pada chapter [Vector](/basic/vector) di mana dalam pendefinisian tipe data harus dituliskan juga tipe data item (via generics parameter), contoh `Vec<i32>`, `Vec<&str>`, dll. Kita juga sempat sedikit belajar tentang topik generic pada chapter [Traits](/basic/traits).
 
 ## A.37.1. Generics basic
 
@@ -20,7 +20,7 @@ fn do_something<T>(arg1: i32, arg2: T) {
 }
 ```
 
-Pada contoh di atas, fungsi `do_something` didefinisikan dengan 2 buah parameter argument dan 1 buah parameter generics. Parameter argument pertama, yaitu `arg1` bertipe `i32`, kemudian diikuti parameter ke-2 bertipe `T` dimana `T` adalah parameter generic fungsi.
+Pada contoh di atas, fungsi `do_something` didefinisikan dengan 2 buah parameter argument dan 1 buah parameter generics. Parameter argument pertama, yaitu `arg1` bertipe `i32`, kemudian diikuti parameter ke-2 bertipe `T` di mana `T` adalah parameter generic fungsi.
 
 Dalam pemanggilan fungsi tersebut, `T` generics dan tipe data argument `arg2` harus sama. Contoh:
 
@@ -81,7 +81,7 @@ Repot kan? Tapi tenang, tidak usah khawatir, ada soluasi agar tipe `T` bisa dima
 
 ### ◉ Contoh ke-1
 
-Contoh pengaplikasiannya bisa dilihat pada kode berikut. Ada sebuah fungsi bernama `print_x_times` yang tugasnya adalah menampilkan data `T` sejumlah `x` kali, dimana `T` adalah parameter generics.
+Contoh pengaplikasiannya bisa dilihat pada kode berikut. Ada sebuah fungsi bernama `print_x_times` yang tugasnya adalah menampilkan data `T` sejumlah `x` kali, di mana `T` adalah parameter generics.
 
 ```rust
 fn main() {
@@ -291,7 +291,7 @@ impl<T, U> Point<T, U> {
 }
 ```
 
-Bisa dilihat pada kode di atas, ada method `get_x` untuk mengambil nilai `x`. Nilai baliknya bertipe `T` dimana tipe tersebut juga dipakai sebagai tipe data `x`.
+Bisa dilihat pada kode di atas, ada method `get_x` untuk mengambil nilai `x`. Nilai baliknya bertipe `T` di mana tipe tersebut juga dipakai sebagai tipe data `x`.
 
 Kemudian coba gunakan struct `Point` untuk membuat satu atau dua variabel, lalu akses method-nya.
 

--- a/docs/basic/lifetime.md
+++ b/docs/basic/lifetime.md
@@ -188,7 +188,7 @@ Lifetime dituliskan dengan notasi `'nama_lifetime`. Dengan notasi tersebut, kita
 &'a mut i32 // => tipe data mutable reference i32 dengan lifetime 'a
 ```
 
-> Lifetime dan block label memiliki bentuk literal yang sama, keduanya diawali tanda kutip `'`. Yang membedakan hanya pada tempat dimana syntax tersebut ditulis.
+> Lifetime dan block label memiliki bentuk literal yang sama, keduanya diawali tanda kutip `'`. Yang membedakan hanya pada tempat di mana syntax tersebut ditulis.
 
 Kegunaan dari lifetime annotation adalah untuk menginformasikan compiler agar reference tidak langsung didealokasikan setelah eksekusi block selesai. Agar lebih jelas mari kita langsung terapkan saja pada fungsi `get_number` yang sudah ditulis. Silakan tambahkan lifetime dengan nama bebas. Di sini penulis gunakan `'my_lifetime`.nnnn
 
@@ -449,7 +449,7 @@ Run program, hasilnya sukses.
 
 ## A.42.8. Generic parameter + trait bounds + lifetime
 
-Lalu bagaimana jika ada fungsi yang disitu ada penerapan trait bounds, ada juga generic parameter, dan lifetime annotation. Cara penulisannya seperti apa? Silakan lihat contoh berikut:
+Lalu bagaimana jika ada fungsi yang di situ ada penerapan trait bounds, ada juga generic parameter, dan lifetime annotation. Cara penulisannya seperti apa? Silakan lihat contoh berikut:
 
 ```rust
 fn find_greater_number<'a, T>(
@@ -471,7 +471,7 @@ Fungsi `find_greater_number` di atas digunakan untuk mencari angka terbesar dari
 
 Tipe `T` diasosiasikan dengan trait `std::cmp::PartialOrd` agar variabel dengan tipe tersebut bisa digunakan dalam seleksi kondisi `if` yang ada dalam block fungsi tersebut.
 
-Ok, sampai sini semoga cukup jelas. Lalu bagaimana dengan lifetime annotation-nya? Karena lifetime annotation definisinya berada pada tempat yang sama dengan definisi tipe generic, maka langsung saja tulis disitu tanpa memperhatikan urutan. Sebagai contoh, dua definisi block fungsi berikut adalah ekuivalen.
+Ok, sampai sini semoga cukup jelas. Lalu bagaimana dengan lifetime annotation-nya? Karena lifetime annotation definisinya berada pada tempat yang sama dengan definisi tipe generic, maka langsung saja tulis di situ tanpa memperhatikan urutan. Sebagai contoh, dua definisi block fungsi berikut adalah ekuivalen.
 
 ```rust
 fn say_hello_v1<'abc, T>()

--- a/docs/basic/method.md
+++ b/docs/basic/method.md
@@ -10,7 +10,7 @@ Pada chapter ini kita akan belajar tentang method beserta perbedaannya dengan *a
 
 Method adalah *associated item* yang hanya bisa diakses lewat instance/object, berbeda dengan *associated function* yang pengaksesan fungsinya via tipe data struct.
 
-Silakan lihat ilustrasi kode berikut, lalu pelajari penjelasan dibawahnya untuk mencari tau perbedaan *associated function* vs method.
+Silakan lihat ilustrasi kode berikut, lalu pelajari penjelasan di bawahnya untuk mencari tau perbedaan *associated function* vs method.
 
 ```rust
 struct Car {
@@ -28,7 +28,7 @@ let my_car: Car = Car::new();
 let info: String = my_car.info();
 ```
 
-- Fungsi `new` disitu adalah *associated function* milik struct `Car`. Dengannya object baru bernama `my_car` bertipe `Car` dibuat.
+- Fungsi `new` di situ adalah *associated function* milik struct `Car`. Dengannya object baru bernama `my_car` bertipe `Car` dibuat.
 - Object `my_car` adalah variabel bertipe `Car`. Via object tersebut method bernama `info` diakses.
 - Method `info` tidak bisa diakses via struct `Car`. Dan *associated function* `new` juga tidak bisa diakses dari instance/object `my_car`.
 
@@ -200,7 +200,7 @@ impl Car {
 
 ![Method](img/method-3.png)
 
-Hmm, tapi kenapa terdeteksi error? Penyebabnya error tersebut adalah karena **mutable reference** tidak digunakan dalam pengaksesan current object yang padahal ada operasi *mutable* atau perubahan nilai terhadap property disitu. Syntax `&self` artinya operasi peminjaman object `self` adalah *read only*.
+Hmm, tapi kenapa terdeteksi error? Penyebabnya error tersebut adalah karena **mutable reference** tidak digunakan dalam pengaksesan current object yang padahal ada operasi *mutable* atau perubahan nilai terhadap property di situ. Syntax `&self` artinya operasi peminjaman object `self` adalah *read only*.
 
 Cara mengambil mutable reference dari object `self` adalah dengan menggunakan `&mut self`. Cara tersebut kurang lebih sama seperti pengambilan mutable reference dari variabel biasa.
 

--- a/docs/basic/module-basic.md
+++ b/docs/basic/module-basic.md
@@ -16,7 +16,7 @@ Di Rust, module memiliki hirarki (biasa disebut dengan *module tree*) yang *root
 
 Rust memiliki 2 jenis modul, yaitu *normal module* dan *inline module*. Pembahasan dimulai dengan normal module terlebih dahulu.
 
-Keyword `mod` digunakan untuk mendefinisikan/mendaftarkan sebuah module. Nama module menjadi path dimana isi module atau *module item* harus berada. Sebagai contoh:
+Keyword `mod` digunakan untuk mendefinisikan/mendaftarkan sebuah module. Nama module menjadi path di mana isi module atau *module item* harus berada. Sebagai contoh:
 
 - module yang didefinisikan dengan nama `my_number`, maka item-nya harus berada pada file `my_number.rs` atau `my_number/mod.rs`
 - module yang didefinisikan dengan nama `my_io`, maka item-nya harus berada pada file `my_io.rs` atau `my_io/mod.rs`
@@ -68,11 +68,11 @@ Ok, kita telah menyiapkan satu item milik module `my_io` yaitu sebuah fungsi ber
 
 Keyword `pub` digunakan untuk menjadikan suatu item menjadi **public**, agar bisa diakses dari luar module.
 
-Fungsi `read_entry` ini berada dalam module `my_io`. Jika tidak ada keyword `pub` disitu, maka fungsi `read_entry` hanya bisa diakses dari dalam `my_io` saja, tidak bisa diakses dari luar module contohnya seperti dari `main.rs`. Dengan menjadikan `read_entry` sebagai fungsi yang public, maka fungsi tersebut bisa diakses dari `main.rs`.
+Fungsi `read_entry` ini berada dalam module `my_io`. Jika tidak ada keyword `pub` di situ, maka fungsi `read_entry` hanya bisa diakses dari dalam `my_io` saja, tidak bisa diakses dari luar module contohnya seperti dari `main.rs`. Dengan menjadikan `read_entry` sebagai fungsi yang public, maka fungsi tersebut bisa diakses dari `main.rs`.
 
 > Lebih jelasnya mengenai keyword `pub` dibahas pada chapter [Module System ➜ Visibility & Privacy](/basic/visibility-privacy)
 
-Isi module sudah siap, selanjutnya lanjut ke pendefinisian modul. Umumnya pada bahasa pemrograman, definisi module adalah ada dalam file dimana isi module berada, namun tidak untuk Rust.
+Isi module sudah siap, selanjutnya lanjut ke pendefinisian modul. Umumnya pada bahasa pemrograman, definisi module adalah ada dalam file di mana isi module berada, namun tidak untuk Rust.
 
 Di Rust, definisi sebuah module (sekali lagi bukan item/isinya ya, tapi definisi dari module itu sendiri) dituliskan pada file terpisah, yaitu di file entrypoint crate, yaitu `main.rs` atau `lib.rs`.
 
@@ -234,7 +234,7 @@ Method `parse` menghasilkan data bertipe *generic result type* atau `Result<T, E
 
 Sampai bagian ini kita telah belajar tentang module beserta 2 macam cara penerapannya.
 
-Sebuah module bisa saja memiliki module dibawahnya (biasa disebut submodule), dan hal ini adalah konsep yang umum dalam bahasa pemrograman. Di Rust, aturan dalam pembuatan submodule masih sama seperti module, perbedaannya adalah tempat dimana submodule didefinisikan. Jika pada root module definisi ada pada file `main.rs` atau `lib.rs`, maka pada submodule definisi ada pada file dimana *parent module* berada.
+Sebuah module bisa saja memiliki module di bawahnya (biasa disebut submodule), dan hal ini adalah konsep yang umum dalam bahasa pemrograman. Di Rust, aturan dalam pembuatan submodule masih sama seperti module, perbedaannya adalah tempat di mana submodule didefinisikan. Jika pada root module definisi ada pada file `main.rs` atau `lib.rs`, maka pada submodule definisi ada pada file di mana *parent module* berada.
 
 Sebagai contoh jika pada program sebelumnya kita tambahkan module `my_number` yang sudah dibuat, jika ada submodule dengan nama `conversion_utility`, maka definisi module berada di `my_number/mod.rs` dan itemnya di `my_number/conversion_utility/mod.rs`.
 

--- a/docs/basic/module-inline.md
+++ b/docs/basic/module-inline.md
@@ -239,7 +239,7 @@ Jalankan program untuk melihat hasilnya.
 
 Pada kode di atas, `path` yang digunakan bukan `utilities/random.rs` melainkan `random.rs`, hail ini dikarenakan `path` attribute dipanggil **di dalam module `utilities`**, menjadikan current path pada blok kode tersebut menjadi `utilities/`.
 
-Silakan coba ubah isi `path` attribute menjadi `utilities/random.rs`, hasilnya adalah error. Rust akan menggunakan gabungan dari current path (`utilities/`) dan path pada `path` attribute (`utilities/random.rs`) dalam lookup, jadinya yang di-lookup adalah `utilities/utilities/random.rs`, dan hasilnya error karena tidak ada file disana.
+Silakan coba ubah isi `path` attribute menjadi `utilities/random.rs`, hasilnya adalah error. Rust akan menggunakan gabungan dari current path (`utilities/`) dan path pada `path` attribute (`utilities/random.rs`) dalam lookup, jadinya yang di-lookup adalah `utilities/utilities/random.rs`, dan hasilnya error karena tidak ada file di sana.
 
 ![Rust Inline Module](img/module-inline-4.png)
 

--- a/docs/basic/module-scope-item-access.md
+++ b/docs/basic/module-scope-item-access.md
@@ -8,9 +8,9 @@ Pembahasan chapter ini masih dalam lingkup module system, yaitu tentang scope da
 
 ## A.22.1. Scope
 
-Scope bisa diartikan dengan: representasi dimana kode berada. Apapun yang ditulis dalam blok kode (ditandai dengan diapit tanda kurung kurawal `{ }`) berarti dalam satu scope yang sama.
+Scope bisa diartikan dengan: representasi di mana kode berada. Apapun yang ditulis dalam blok kode (ditandai dengan diapit tanda kurung kurawal `{ }`) berarti dalam satu scope yang sama.
 
-Agar lebih jelas, lihat kode berikut kemudian pelajari penjelasan dibawahnya:
+Agar lebih jelas, lihat kode berikut kemudian pelajari penjelasan di bawahnya:
 
 ```rust
 const PI: f64 = 3.14;
@@ -134,7 +134,7 @@ fn main() {
 
 Pada contoh bisa dilihat ada dua buah fungsi dideklarasikan dengan nama yang sama persis, yang satu berada di *crate root*, satunya lagi merupakan item milik `my_mod`.
 
-Di dalam `my_mod::run_the_app` ada 2 kali pemanggilan fungsi `my_func`, satunya menggunakan keyword `self` dan satunya tidak. Fungsi `my_func` manakah yang dipanggil? Hasilnya bisa dilihat pada gambar dibawah ini.
+Di dalam `my_mod::run_the_app` ada 2 kali pemanggilan fungsi `my_func`, satunya menggunakan keyword `self` dan satunya tidak. Fungsi `my_func` manakah yang dipanggil? Hasilnya bisa dilihat pada gambar di bawah ini.
 
 ![Module item access self](img/module-scope-item-access-2.png)
 

--- a/docs/basic/option-type.md
+++ b/docs/basic/option-type.md
@@ -16,7 +16,7 @@ Tipe data `Option` adalah enum dengan isi 2 buah enum value:
 > - `None` bisa disamakan dengan nilai `null` atau `nil` pada bahasa pemrograman lain.
 > - `T` merupakan parameter generic. Lebih jelasnya mengenai generic dibahas pada chapter [Generics](/basic/generics).
 
-Tipe data `Option` memiliki notasi penulisan `Option<T>` dimana `T` adalah tipe data sebenarnya yang dibungkus oleh enum value `Some`.
+Tipe data `Option` memiliki notasi penulisan `Option<T>` di mana `T` adalah tipe data sebenarnya yang dibungkus oleh enum value `Some`.
 
 Berikut adalah contoh cara penerapan `Option`.
 
@@ -56,7 +56,7 @@ Output program di atas saat di-run:
 
 Dalam penerapannya, ketika ada data bertipe `Option` artinya data tersebut berpotensi untuk berisi nilai `None` atau `Some<T>`, pasti antara 2 nilai tersebut.
 
-Umumnya penggunaan tipe `Option` selalu diikuti dengan seleksi kondisi. Keyword `if` bisa digunakan dalam seleksi kondisi, namun dalam Praktiknya lebih baik menggunakan keyword `match` karena memberikan kemudahan dalam pengaksesan nilai `T` milik `Some` (dimana `T` adalah data yang kita cari dibungkus dalam enum value `Some`).
+Umumnya penggunaan tipe `Option` selalu diikuti dengan seleksi kondisi. Keyword `if` bisa digunakan dalam seleksi kondisi, namun dalam Praktiknya lebih baik menggunakan keyword `match` karena memberikan kemudahan dalam pengaksesan nilai `T` milik `Some` (di mana `T` adalah data yang kita cari dibungkus dalam enum value `Some`).
 
 Mari kita praktikkan. Ubah isi fungsi `main` dengan kode berikut:
 
@@ -218,7 +218,7 @@ println!("result: {}", number);
 // result: 0
 ```
 
-Closure harus dalam notasi `FnOnce() -> T` dimana `T` pada konteks ini adalah `i32`.
+Closure harus dalam notasi `FnOnce() -> T` di mana `T` pada konteks ini adalah `i32`.
 
 > Closure `|| 0` adalah kependekan dari `|| -> i32 { 0 }`.
 >

--- a/docs/basic/option-type.md
+++ b/docs/basic/option-type.md
@@ -16,7 +16,7 @@ Tipe data `Option` adalah enum dengan isi 2 buah enum value:
 > - `None` bisa disamakan dengan nilai `null` atau `nil` pada bahasa pemrograman lain.
 > - `T` merupakan parameter generic. Lebih jelasnya mengenai generic dibahas pada chapter [Generics](/basic/generics).
 
-Tipe data `Option` memiliki notasi penulisan `Option<T>` di mana `T` adalah tipe data sebenarnya yang dibungkus oleh enum value `Some`.
+Tipe data `Option` memiliki notasi penulisan `Option<T>` yang mana `T` adalah tipe data sebenarnya yang dibungkus oleh enum value `Some`.
 
 Berikut adalah contoh cara penerapan `Option`.
 
@@ -56,7 +56,7 @@ Output program di atas saat di-run:
 
 Dalam penerapannya, ketika ada data bertipe `Option` artinya data tersebut berpotensi untuk berisi nilai `None` atau `Some<T>`, pasti antara 2 nilai tersebut.
 
-Umumnya penggunaan tipe `Option` selalu diikuti dengan seleksi kondisi. Keyword `if` bisa digunakan dalam seleksi kondisi, namun dalam Praktiknya lebih baik menggunakan keyword `match` karena memberikan kemudahan dalam pengaksesan nilai `T` milik `Some` (di mana `T` adalah data yang kita cari dibungkus dalam enum value `Some`).
+Umumnya penggunaan tipe `Option` selalu diikuti dengan seleksi kondisi. Keyword `if` bisa digunakan dalam seleksi kondisi, namun dalam Praktiknya lebih baik menggunakan keyword `match` karena memberikan kemudahan dalam pengaksesan nilai `T` milik `Some` (yang mana `T` adalah data yang kita cari dibungkus dalam enum value `Some`).
 
 Mari kita praktikkan. Ubah isi fungsi `main` dengan kode berikut:
 
@@ -218,7 +218,7 @@ println!("result: {}", number);
 // result: 0
 ```
 
-Closure harus dalam notasi `FnOnce() -> T` di mana `T` pada konteks ini adalah `i32`.
+Closure harus dalam notasi `FnOnce() -> T` yang mana `T` pada konteks ini adalah `i32`.
 
 > Closure `|| 0` adalah kependekan dari `|| -> i32 { 0 }`.
 >

--- a/docs/basic/ownership.md
+++ b/docs/basic/ownership.md
@@ -263,7 +263,7 @@ Pada kode di atas, data variabel `msg` owner-nya berpindah ke parameter bernama 
 
 Ok, sampai di sini semoga cukup jelas ya tentang bagaimana proses transfer ownership terjadi pada data yang mengadopsi *move semantics*.
 
-Untuk data bertipe primitif (yang mengadopsi *copy semantics*) kita tidak perlu repot memikirkan dimana owner datanya, karena setiap operasi assignment, data akan di-copy dan hasilnya ada data baru dengan owner baru.
+Untuk data bertipe primitif (yang mengadopsi *copy semantics*) kita tidak perlu repot memikirkan di mana owner datanya, karena setiap operasi assignment, data akan di-copy dan hasilnya ada data baru dengan owner baru.
 
 Tapi kalau dipikir-pikir justru lebih repot mengurus data yang ownernya berpindah saat assignment. Sebagai contoh, misal variabel digunakan di fungsi lain, kemudian digunakan lagi di scope asalnya. Repot juga kalau setiap saat harus dikembalikan lagi via return value.
 

--- a/docs/basic/ownership.md
+++ b/docs/basic/ownership.md
@@ -263,7 +263,7 @@ Pada kode di atas, data variabel `msg` owner-nya berpindah ke parameter bernama 
 
 Ok, sampai di sini semoga cukup jelas ya tentang bagaimana proses transfer ownership terjadi pada data yang mengadopsi *move semantics*.
 
-Untuk data bertipe primitif (yang mengadopsi *copy semantics*) kita tidak perlu repot memikirkan di mana owner datanya, karena setiap operasi assignment, data akan di-copy dan hasilnya ada data baru dengan owner baru.
+Untuk data bertipe primitif (yang mengadopsi *copy semantics*) kita tidak perlu repot memikirkan di mana letak owner datanya, karena setiap operasi assignment, data akan di-copy dan hasilnya ada data baru dengan owner baru.
 
 Tapi kalau dipikir-pikir justru lebih repot mengurus data yang ownernya berpindah saat assignment. Sebagai contoh, misal variabel digunakan di fungsi lain, kemudian digunakan lagi di scope asalnya. Repot juga kalau setiap saat harus dikembalikan lagi via return value.
 

--- a/docs/basic/package-crate.md
+++ b/docs/basic/package-crate.md
@@ -16,7 +16,7 @@ Crate bisa berisi banyak *module*. Sebuah module definisinya bisa berada di bany
 - `Mod_ABC` adalah module yang didefinisikan dalam crate `XYZ`, source code-nya berada di file bernama `modul_a.rs`.
 - `Mod_DEF` adalah module yang didefinisikan dalam crate `XYZ`, source code-nya berada di beberapa file `module_b_one.rs` dan `module_b_two.rs`.
 
-Dari contoh di atas, crate `XYZ` adalah 1 unit kompilasi, yang dimana di dalam crate tersebut ada dua modules yaitu `Mod_ABC` dan `Mod_DEF`
+Dari contoh di atas, crate `XYZ` adalah 1 unit kompilasi, yang di mana di dalam crate tersebut ada dua modules yaitu `Mod_ABC` dan `Mod_DEF`
 
 Rust mengkategorikan crate menjadi 2 jenis, *binary crate* dan *library crate*
 

--- a/docs/basic/package-crate.md
+++ b/docs/basic/package-crate.md
@@ -16,7 +16,7 @@ Crate bisa berisi banyak *module*. Sebuah module definisinya bisa berada di bany
 - `Mod_ABC` adalah module yang didefinisikan dalam crate `XYZ`, source code-nya berada di file bernama `modul_a.rs`.
 - `Mod_DEF` adalah module yang didefinisikan dalam crate `XYZ`, source code-nya berada di beberapa file `module_b_one.rs` dan `module_b_two.rs`.
 
-Dari contoh di atas, crate `XYZ` adalah 1 unit kompilasi, yang di mana di dalam crate tersebut ada dua modules yaitu `Mod_ABC` dan `Mod_DEF`
+Dari contoh di atas, crate `XYZ` adalah 1 unit kompilasi, yang mana di dalam crate tersebut ada dua modules yaitu `Mod_ABC` dan `Mod_DEF`
 
 Rust mengkategorikan crate menjadi 2 jenis, *binary crate* dan *library crate*
 

--- a/docs/basic/path-item.md
+++ b/docs/basic/path-item.md
@@ -125,11 +125,11 @@ let mut message = String::new();
 
 ### ◉ `std::io::stdin()`
 
-Berbeda dengan `String`, path `std::io::stdin` tidak otomatis ter-import, jadi harus dituliskan secara full meskipun sama-sama dibawah crate *Rust Standard Library*.
+Berbeda dengan `String`, path `std::io::stdin` tidak otomatis ter-import, jadi harus dituliskan secara full meskipun sama-sama di bawah crate *Rust Standard Library*.
 
 Path `std::io` berisi module untuk keperluan I/O atau input output. Salah satu item yang ada dalam module ini adalah `stdin`, yang merupakan sebuah fungsi berguna untuk pembuatan objek handler untuk keperluan yang berhubungan dengan console (*stdin*). Objek tersebut ditampung oleh variabel `stdin_reader`.
 
-> Secara terminologi, *stdin* (yang merupakan kependekan dari *standard input*) adalah sebuah input stream dimana data dikirim dan dibaca oleh program.
+> Secara terminologi, *stdin* (yang merupakan kependekan dari *standard input*) adalah sebuah input stream di mana data dikirim dan dibaca oleh program.
 
 Variabel `stdin_reader` ini kemudian kita gunakan untuk berinteraksi dengan input stream, untuk menangkap inputan user.
 
@@ -191,7 +191,7 @@ let stdin_reader = stdin();
 
 Dengan menggunakan `use` kita bisa memperpendek pengaksesan sebuah path.
 
-O iya keyword ini bisa digunakan dimana saja, artinya tidak harus di luar fungsi `main`. Bisa saja di dalam fungsi, atau di dalam blok kode seleksi kondisi atau lainnya.
+O iya keyword ini bisa digunakan di mana saja, artinya tidak harus di luar fungsi `main`. Bisa saja di dalam fungsi, atau di dalam blok kode seleksi kondisi atau lainnya.
 
 ### ◉ Import beberapa items yang parent path-nya yang sama
 
@@ -208,7 +208,7 @@ use std::io::{stdin, stderr};
 
 ### ◉ Import semua items dalam suatu path
 
-Suatu path bisa saja memiliki cukup banyak item/child dibawahnya. Sebagai contoh, path `std::io` merupakan parent path dari `stdin` dan `stderr`. Selain dua items tersebut, ada juga item lainnya.
+Suatu path bisa saja memiliki cukup banyak item/child di bawahnya. Sebagai contoh, path `std::io` merupakan parent path dari `stdin` dan `stderr`. Selain dua items tersebut, ada juga item lainnya.
 
 Ada shortcut yang membuat penulisan import path lebih praktis, tidak perlu menuliskan satu-per-satu, caranya adalah menggunakan `*`. Sebagai contoh:
 

--- a/docs/basic/path-item.md
+++ b/docs/basic/path-item.md
@@ -129,7 +129,7 @@ Berbeda dengan `String`, path `std::io::stdin` tidak otomatis ter-import, jadi h
 
 Path `std::io` berisi module untuk keperluan I/O atau input output. Salah satu item yang ada dalam module ini adalah `stdin`, yang merupakan sebuah fungsi berguna untuk pembuatan objek handler untuk keperluan yang berhubungan dengan console (*stdin*). Objek tersebut ditampung oleh variabel `stdin_reader`.
 
-> Secara terminologi, *stdin* (yang merupakan kependekan dari *standard input*) adalah sebuah input stream di mana data dikirim dan dibaca oleh program.
+> Secara terminologi, *stdin* (merupakan kependekan dari *standard input*) adalah sebuah input stream yang nilainya dibaca oleh program sebagai inputan.
 
 Variabel `stdin_reader` ini kemudian kita gunakan untuk berinteraksi dengan input stream, untuk menangkap inputan user.
 

--- a/docs/basic/perulangan-for-in.md
+++ b/docs/basic/perulangan-for-in.md
@@ -23,11 +23,11 @@ for i in 0..5 {
 
 ![perulangan for in](img/perulangan-for-in-1.png)
 
-Keyword `for in` jika digunakan pada notasi iterator `a..b` maka akan menghasilkan sebuah perulangan dari angka `a` hingga angka dibawah `b`.
+Keyword `for in` jika digunakan pada notasi iterator `a..b` maka akan menghasilkan sebuah perulangan dari angka `a` hingga angka di bawah `b`.
 
-Pada contoh di atas, `0..5` artinya adalah objek iterator yang dimulai dari angka `0` hingga dibawah `5` (yaitu `4`). Object iterator tersebut kemudian diiterasi, dan ditiap perulangan di-print menggunakan `println!("{i}")`. Dengan ini, nilai `i` muncul di layar console dimulai angka `0` hingga `4`.
+Pada contoh di atas, `0..5` artinya adalah objek iterator yang dimulai dari angka `0` hingga di bawah `5` (yaitu `4`). Object iterator tersebut kemudian diiterasi, dan ditiap perulangan di-print menggunakan `println!("{i}")`. Dengan ini, nilai `i` muncul di layar console dimulai angka `0` hingga `4`.
 
-Jika ingin melakukan perulangan dari `a` ke `b` (bukan dari `a` ke angka dibawah `b`) gunakan notasi iterator `a..=b`. Contoh:
+Jika ingin melakukan perulangan dari `a` ke `b` (bukan dari `a` ke angka di bawah `b`) gunakan notasi iterator `a..=b`. Contoh:
 
 ```rust
 for i in 0..=5 {

--- a/docs/basic/perulangan-loop-break-continue-label.md
+++ b/docs/basic/perulangan-loop-break-continue-label.md
@@ -112,7 +112,7 @@ loop {
 
 ## A.11.5. Label perulangan
 
-Statement perulangan menggunakan `loop` bisa ditandai dengan label. Manfaat dari penggunaan label adalah bisa mengeksekusi `break` atau `continue` ke perulangan di luar blok kode perulangan di mana statement itu berada. Umumnya label perulangan dipergunakan pada nested loop, di mana ada kebutuhan untuk menghentikan/melanjutkan paksa perulangan terluar.
+Statement perulangan menggunakan `loop` bisa ditandai dengan label. Manfaat dari penggunaan label adalah bisa mengeksekusi `break` atau `continue` ke perulangan di luar blok kode perulangan di mana statement itu berada. Umumnya label perulangan dipergunakan pada nested loop untuk keperluan menghentikan/melanjutkan paksa perulangan terluar.
 
 Berikut adalah notasi penulisan loop dengan dan tanpa label. Nama label diawali dengan tanda petik `'`.
 

--- a/docs/basic/perulangan-loop-break-continue-label.md
+++ b/docs/basic/perulangan-loop-break-continue-label.md
@@ -87,7 +87,7 @@ loop {
 
 `continue` digunakan untuk melanjutkan paksa sebuah perulangan, kebalikan dari `break` yang fungsinya menghentikan paksa sebuah perulangan.
 
-Source code berikut murapakan contoh penerapan `continue`. Variabel `i` berperan sebagai counter perulangan. Jika nilai `i` adalah ganjil, maka perulangan dipaksa lanjut ke iterasi berikutnya. Dengan ini maka macro `println` hanya akan menampilkan nilai genap. Dan program akan berhenti jika `i` nilainya lebih dari `max`.
+Source code berikut merupakan contoh penerapan `continue`. Variabel `i` berperan sebagai counter perulangan. Jika nilai `i` adalah ganjil, maka perulangan dipaksa lanjut ke iterasi berikutnya. Dengan ini maka macro `println` hanya akan menampilkan nilai genap. Dan program akan berhenti jika `i` nilainya lebih dari `max`.
 
 ```rust
 let mut i = 0;
@@ -112,7 +112,7 @@ loop {
 
 ## A.11.5. Label perulangan
 
-Statement perulangan menggunakan `loop` bisa ditandai dengan label. Manfaat dari penggunaan label adalah bisa mengeksekusi `break` atau `continue` ke perulangan di luar blok kode perulangan dimana statement itu berada. Umumnya label perulangan dipergunakan pada nested loop, dimana ada kebutuhan untuk menghentikan/melanjutkan paksa perulangan terluar.
+Statement perulangan menggunakan `loop` bisa ditandai dengan label. Manfaat dari penggunaan label adalah bisa mengeksekusi `break` atau `continue` ke perulangan di luar blok kode perulangan di mana statement itu berada. Umumnya label perulangan dipergunakan pada nested loop, di mana ada kebutuhan untuk menghentikan/melanjutkan paksa perulangan terluar.
 
 Berikut adalah notasi penulisan loop dengan dan tanpa label. Nama label diawali dengan tanda petik `'`.
 
@@ -130,7 +130,7 @@ loop {
 }
 ```
 
-Mari kita pelajari dan praktikkan kode berikut ini. Dibawah ini adalah sebuah program sederhana menampilkan angka yang hasilnya bisa dilihat digambar dibawahnya. Perulangan di level 2 akan dihentikan secara paksa ketika `j > i`. Sedangkan perulangan level pertama atau terluar (dengan label `'mainLoop`) akan dihentikan paksa dari perulangan level 2 jika kondisi `i > max`.
+Mari kita pelajari dan praktikkan kode berikut ini. Di bawah ini adalah sebuah program sederhana menampilkan angka yang hasilnya bisa dilihat pada gambar di bawahnya. Perulangan di level 2 akan dihentikan secara paksa ketika `j > i`. Sedangkan perulangan level pertama atau terluar (dengan label `'mainLoop`) akan dihentikan paksa dari perulangan level 2 jika kondisi `i > max`.
 
 ```rust
 let mut i = 0;

--- a/docs/basic/perulangan-while.md
+++ b/docs/basic/perulangan-while.md
@@ -18,7 +18,7 @@ while kondisi {
 }
 ```
 
-Contoh berikut adalah penerapan `while` untuk operasi perulangan yang isinya menampilkan angka `i` dengan kondisi `i` dibawah `max`.
+Contoh berikut adalah penerapan `while` untuk operasi perulangan yang isinya menampilkan angka `i` dengan kondisi `i` di bawah `max`.
 
 ```rust
 let mut i = 0;
@@ -32,7 +32,7 @@ while i < max {
 
 ![keyword while](img/perulangan-while-1.png)
 
-Variabel `i` pada contoh di atas menjadi penentu kapan perulangan berhenti. Di dalam blok kode `while` (yang dimana akan dieksekusi setiap kondisi menghasilkan nilai `true`), nilai variabel `i` di-increment, membuat variabel `i` nilainya selalu bertambah 1 setiap kali perulangan. Perulangan akan berhenti ketika nilai `i` sudah tidak dibawah `max` lagi.
+Variabel `i` pada contoh di atas menjadi penentu kapan perulangan berhenti. Di dalam blok kode `while` (yang di mana akan dieksekusi setiap kondisi menghasilkan nilai `true`), nilai variabel `i` di-increment, membuat variabel `i` nilainya selalu bertambah 1 setiap kali perulangan. Perulangan akan berhenti ketika nilai `i` sudah tidak di bawah `max` lagi.
 
 ## A.10.2. Nested `while`
 

--- a/docs/basic/perulangan-while.md
+++ b/docs/basic/perulangan-while.md
@@ -32,7 +32,7 @@ while i < max {
 
 ![keyword while](img/perulangan-while-1.png)
 
-Variabel `i` pada contoh di atas menjadi penentu kapan perulangan berhenti. Di dalam blok kode `while` (yang di mana akan dieksekusi setiap kondisi menghasilkan nilai `true`), nilai variabel `i` di-increment, membuat variabel `i` nilainya selalu bertambah 1 setiap kali perulangan. Perulangan akan berhenti ketika nilai `i` sudah tidak di bawah `max` lagi.
+Variabel `i` pada contoh di atas menjadi penentu kapan perulangan berhenti. Di dalam blok kode `while` (yang mana akan dieksekusi setiap kondisi menghasilkan nilai `true`), nilai variabel `i` di-increment, membuat variabel `i` nilainya selalu bertambah 1 setiap kali perulangan. Perulangan akan berhenti ketika nilai `i` sudah tidak di bawah `max` lagi.
 
 ## A.10.2. Nested `while`
 

--- a/docs/basic/pointer-references.md
+++ b/docs/basic/pointer-references.md
@@ -36,7 +36,7 @@ println!("pointer: {:p}", pointer_number);
 
 Pada contoh di atas, sebuah variabel dideklarasikan bernama `number` dengan tipe data adalah numerik dan value `24`. Variabel tersebut jika di-print akan muncul nilainya, yaitu `24`.
 
-Ada satu lagi variabel yang dideklarasikan yaitu `pointer_number`, yang nilainya adalah *reference* dari variabel `number`. Cara pengambilan reference yang dilihat pada contoh, yaitu dengan menambahkan operator `&` pada variabel yang ingin dimabil pointernya.
+Ada satu lagi variabel yang dideklarasikan yaitu `pointer_number`, yang nilainya adalah *reference* dari variabel `number`. Cara pengambilan reference yang dilihat pada contoh, yaitu dengan menambahkan operator `&` pada variabel yang ingin diambil pointernya.
 
 ```rust
 // variabel pointer_number nilainya adalah reference variabel number.
@@ -102,7 +102,7 @@ Ok, lalu kenapa muncul error? Di gambar terlihat ada garis merah dan popup pesan
 
 Penyebab erronya bukan dari statement tersebut, tetapi pada baris statement pengambilan reference variabel `number`. Statement `&number` artinya adalah mengambil reference dari variabel `number`. Di atas sempat kita bahas bahwa *by default* sebuah reference tidak bisa diubah nilainya (*immutable*), dan ini adalah penyebab error yang dialami.
 
-> Silakan perhatikan pesan di popup error message agar mudah untuk tau dimana sumber masalahnya.
+> Silakan perhatikan pesan di popup error message agar mudah untuk tau di mana sumber masalahnya.
 
 Perubahan isi nilai variabel `number` tidak menghasilkan error, hal ini karena number adalah variabel `number` adalah mutable. Sedangkan operasi perubahan nilai variabel `*pointer_number` pada contoh di atas, dianggap sebagai error karena variabel `pointer_number` reference-nya adalah bukan mutable (meskipun reference diperoleh dari variabel `number` yang notabene mutable).
 
@@ -175,7 +175,7 @@ Ok, lanjut. Per sekarang, reference variabel `number_one` dan `number_two` adala
 
 ### ◉ Contoh ke-1
 
-Contoh penerapannya bisa kita lihat pada chapter [Pointer & References](/basic/pointer-references#a315-karakteristik-pointer--reference) chapter ini, disitu bisa dilihat ada variabel mutable `number` dan `pointer_number` yang reference-nya adalah sama dengan variabel `number`. Ketika underlying value `pointer_number` diubah (dari `24` ke `12`), isi data variabel `number` juga berubah.
+Contoh penerapannya bisa kita lihat pada chapter [Pointer & References](/basic/pointer-references#a315-karakteristik-pointer--reference) ini, di situ bisa dilihat ada variabel mutable `number` dan `pointer_number` yang reference-nya adalah sama dengan variabel `number`. Ketika underlying value `pointer_number` diubah (dari `24` ke `12`), isi data variabel `number` juga berubah.
 
 ![Pointer & reference](img/pointer-references-4.png)
 

--- a/docs/basic/result-type.md
+++ b/docs/basic/result-type.md
@@ -17,7 +17,7 @@ Tipe data `Result` adalah enum dengan isi 2 buah enum value:
 
 > - `T` dan `E` merupakan parameter generic. Lebih jelasnya mengenai generic dibahas pada chapter [Generics](/basic/generics).
 
-Tipe data `Result` memiliki notasi penulisan `Result<T, E>` dimana `T` digunakan pada enum value `Ok<T>` dan `E` digunakan enum value `Err<E>`.
+Tipe data `Result` memiliki notasi penulisan `Result<T, E>` di mana `T` digunakan pada enum value `Ok<T>` dan `E` digunakan enum value `Err<E>`.
 
 Cara penerapan tipe data ini bisa dilihat pada kode berikut:
 
@@ -233,7 +233,7 @@ println!("result: {}", number);
 // result: 0
 ```
 
-Closure harus dalam notasi `FnOnce(E) -> T` dimana `T` pada konteks ini adalah `f64`.
+Closure harus dalam notasi `FnOnce(E) -> T` di mana `T` pada konteks ini adalah `f64`.
 
 > Lebih jelasnya mengenai closure dibahas pada chapter [Closures](/basic/closures).
 

--- a/docs/basic/result-type.md
+++ b/docs/basic/result-type.md
@@ -17,7 +17,7 @@ Tipe data `Result` adalah enum dengan isi 2 buah enum value:
 
 > - `T` dan `E` merupakan parameter generic. Lebih jelasnya mengenai generic dibahas pada chapter [Generics](/basic/generics).
 
-Tipe data `Result` memiliki notasi penulisan `Result<T, E>` di mana `T` digunakan pada enum value `Ok<T>` dan `E` digunakan enum value `Err<E>`.
+Tipe data `Result` memiliki notasi penulisan `Result<T, E>` yang mana `T` digunakan pada enum value `Ok<T>` dan `E` digunakan enum value `Err<E>`.
 
 Cara penerapan tipe data ini bisa dilihat pada kode berikut:
 
@@ -233,7 +233,7 @@ println!("result: {}", number);
 // result: 0
 ```
 
-Closure harus dalam notasi `FnOnce(E) -> T` di mana `T` pada konteks ini adalah `f64`.
+Closure harus dalam notasi `FnOnce(E) -> T` yang mana `T` pada konteks ini adalah `f64`.
 
 > Lebih jelasnya mengenai closure dibahas pada chapter [Closures](/basic/closures).
 

--- a/docs/basic/seleksi-kondisi-if.md
+++ b/docs/basic/seleksi-kondisi-if.md
@@ -23,7 +23,7 @@ Pada notasi di atas, `operasiLogika` bisa diisi dengan variabel yang bertipe `bo
 ```rust
 let number_a = 3;
 if number_a < 5 {
-    println!("number_a adalah dibawah 5");
+    println!("number_a adalah di bawah 5");
 }
 
 let result_a = number_a >= 5;
@@ -34,7 +34,7 @@ if result_a {
 
 ![seleksi kondisi](img/seleksi-kondisi-if-1.png)
 
-Pada kode di atas ada dua buah blok kode `if`. Yang pertama mengecek hasil ekspresi logika `apakah variabel number_a dibawah 5?`. Jika hasilnya benar atau `true` maka blok kode setelahnya yang diapit tanda kurung kurawal akan dieksekusi, hasilnya menampilkan tulisan `angka adalah dibawah 5`.
+Pada kode di atas ada dua buah blok kode `if`. Yang pertama mengecek hasil ekspresi logika `apakah variabel number_a di bawah 5?`. Jika hasilnya benar atau `true` maka blok kode setelahnya yang diapit tanda kurung kurawal akan dieksekusi, hasilnya menampilkan tulisan `angka adalah di bawah 5`.
 
 Blok kode `if` kedua adalah mengecek nilai `bool` variabel `result_a`. Variabel `result_a` sendiri isinya berasal dari ekspresi logika `apakah variabel number_a lebih besar atau sama dengan 5?`. Jika hasilnya `true` maka blok kode setelahnya (yang diapit tanda kurung kurawal) dieksekusi. Namun, pada contoh di atas, hasilnya adalah `false`, karena variabel `number_a` nilainya adalah tidak lebih besar atau sama dengan 5, dengan demikian blok kode tidak dieksekusi.
 
@@ -47,7 +47,7 @@ let number_b = 3;
 if number_b == 2 {
     println!("number_b adalah 2");
 } else if number_b < 2 {
-    println!("number_b adalah dibawah 2");
+    println!("number_b adalah di bawah 2");
 } else {
     println!("number_b adalah di atas 2");
 }
@@ -148,7 +148,7 @@ println!("result_d adalah {result_d}");
 
 ## A.9.5. Kombinasi Keyword `let` dan `if`, Dengan Tipe Data Eksplisit
 
-Ada situasi dimana dalam pemanfaatan `let if` kita perlu men-specify secara eksplisit tipe data variabel penampung. Caranya sama seperti statement deklarasi variabel beserta tipe data, langsung tulis saja tipe data yang diinginkan setelah nama variabel dan sebelum operator `=`.
+Ada situasi di mana dalam pemanfaatan `let if` kita perlu men-specify secara eksplisit tipe data variabel penampung. Caranya sama seperti statement deklarasi variabel beserta tipe data, langsung tulis saja tipe data yang diinginkan setelah nama variabel dan sebelum operator `=`.
 
 Pada contoh berikut, variabel `result_e` saya definisikan tipenya adalah `string literal &str`.
 
@@ -157,7 +157,7 @@ let number_e = 3;
 let result_e: &str = if number_e == 2 {
     "angka adalah 2"
 } else if number_e < 2 {
-    "angka adalah dibawah 2"
+    "angka adalah di bawah 2"
 } else {
     "angka adalah di atas 2"
 };

--- a/docs/basic/slice-memory-management.md
+++ b/docs/basic/slice-memory-management.md
@@ -6,7 +6,7 @@ sidebar_label: A.43. Slice Memory Management
 
 Kita telah mempelajari tipe data [Array](/basic/array) dan [Vector](/basic/vector), serta sudah beberapa kali menggunakan tipe data string slice (`String`). 3 tipe data itu memiliki kemiripan, yaitu kesemuanya termasuk dalam kategori tipe data slice.
 
-> Ciri khas dari tipe data yang termasuk dalam kategori slice adalah jika diakses reference-nya menghasilkan data bertipe `&[T]` dimana `T` adalah tipe data elemen.
+> Ciri khas dari tipe data yang termasuk dalam kategori slice adalah jika diakses reference-nya menghasilkan data bertipe `&[T]` di mana `T` adalah tipe data elemen.
 
 Pada chapter ini, kita akan bahas lebih dalam lagi tentang apa itu slice terutama bagian memory management-nya.
 
@@ -45,7 +45,7 @@ println!("slice2  : {} {:?}", slice2.len(), slice2);
 
 Terlihat kemiripan-nya, slice bisa terbentuk dari ketiga jenis data di atas.
 
-Penulis ingatkan lagi, bahwa slice adalah tipe data reference yang berarti isi adalah data pinjaman (borrow). Tipe data slice selalu `&[T]` dimana `T` adalah tipe data element.
+Penulis ingatkan lagi, bahwa slice adalah tipe data reference yang berarti isi adalah data pinjaman (borrow). Tipe data slice selalu `&[T]` di mana `T` adalah tipe data element.
 
 Karena slice adalah data borrow, maka operasi standar borrowing termasuk mutable borrowing bisa dilakukan di slice.
 

--- a/docs/basic/slice-memory-management.md
+++ b/docs/basic/slice-memory-management.md
@@ -6,7 +6,7 @@ sidebar_label: A.43. Slice Memory Management
 
 Kita telah mempelajari tipe data [Array](/basic/array) dan [Vector](/basic/vector), serta sudah beberapa kali menggunakan tipe data string slice (`String`). 3 tipe data itu memiliki kemiripan, yaitu kesemuanya termasuk dalam kategori tipe data slice.
 
-> Ciri khas dari tipe data yang termasuk dalam kategori slice adalah jika diakses reference-nya menghasilkan data bertipe `&[T]` di mana `T` adalah tipe data elemen.
+> Ciri khas dari tipe data yang termasuk dalam kategori slice adalah jika diakses reference-nya menghasilkan data bertipe `&[T]` yang mana `T` adalah tipe data elemen.
 
 Pada chapter ini, kita akan bahas lebih dalam lagi tentang apa itu slice terutama bagian memory management-nya.
 
@@ -45,13 +45,13 @@ println!("slice2  : {} {:?}", slice2.len(), slice2);
 
 Terlihat kemiripan-nya, slice bisa terbentuk dari ketiga jenis data di atas.
 
-Penulis ingatkan lagi, bahwa slice adalah tipe data reference yang berarti isi adalah data pinjaman (borrow). Tipe data slice selalu `&[T]` di mana `T` adalah tipe data element.
+Penulis ingatkan lagi, bahwa slice adalah tipe data reference yang berarti isi adalah data pinjaman (borrow). Tipe data slice selalu `&[T]` yang mana `T` adalah tipe data element.
 
 Karena slice adalah data borrow, maka operasi standar borrowing termasuk mutable borrowing bisa dilakukan di slice.
 
 ## A.43.2. Memory management pada slice
 
-Sekarang lanjut ke pembahasan tentang bagaimana data bertipe slice di manage di-memory. Sebagai bahan belajar, kita perlu memilih satu dari 3 tipe data slice yang ada. Bebas sebenarnya mau pilih yang mana. Penulis memilih `String` untuk memulai pembahasan.
+Sekarang lanjut ke pembahasan tentang bagaimana data bertipe slice di-manage di memory. Sebagai bahan belajar, kita perlu memilih satu dari 3 tipe data slice yang ada. Bebas sebenarnya mau pilih yang mana. Penulis memilih `String` untuk memulai pembahasan.
 
 Silakan perhatikan statement sederhana berikut:
 

--- a/docs/basic/slice.md
+++ b/docs/basic/slice.md
@@ -22,7 +22,7 @@ Lalu apa itu slice? menurut laman dokumentasi Rust, slice adalah:
 >
 > Slices are a view into a block of memory represented as a pointer and a size.
 
-Slice adalah representasi *block of memory* berbentuk pointer dan memiliki size yang dinamis (tidak fixed seperti array). Notasi tipe data slice adalah `&[T]` di mana `T` adalah tipe data element.
+Slice adalah representasi *block of memory* berbentuk pointer dan memiliki size yang dinamis (tidak fixed seperti array). Notasi tipe data slice adalah `&[T]` yang mana `T` adalah tipe data element.
 
 Slice bisa dibuat dari data array (atau dari tipe kolektif data lainnya) dengan menggunakan kombinasi operator `&` dan *range syntax* `..` dengan notasi penulisan seperti berikut:
 

--- a/docs/basic/slice.md
+++ b/docs/basic/slice.md
@@ -22,7 +22,7 @@ Lalu apa itu slice? menurut laman dokumentasi Rust, slice adalah:
 >
 > Slices are a view into a block of memory represented as a pointer and a size.
 
-Slice adalah representasi *block of memory* berbentuk pointer dan memiliki size yang dinamis (tidak fixed seperti array). Notasi tipe data slice adalah `&[T]` dimana `T` adalah tipe data element.
+Slice adalah representasi *block of memory* berbentuk pointer dan memiliki size yang dinamis (tidak fixed seperti array). Notasi tipe data slice adalah `&[T]` di mana `T` adalah tipe data element.
 
 Slice bisa dibuat dari data array (atau dari tipe kolektif data lainnya) dengan menggunakan kombinasi operator `&` dan *range syntax* `..` dengan notasi penulisan seperti berikut:
 
@@ -268,7 +268,7 @@ Nantinya setelah selesai dengan pembahasan dasar memory management di Rust, kita
 Catatan ringkas perihal slice:
 
 - Slice memiliki notasi `&[T]`
-  - `&` disitu artinya adalah operasi borrowing/peminjaman
+  - `&` di situ artinya adalah operasi borrowing/peminjaman
   - `T` adalah tipe data tiap elemen
 - Slice bisa terbentuk dari hasil meminjam data array, vector, atau tipe data kolektif lainnya
 - Data slice adalah selalu data pinjaman

--- a/docs/basic/string-slice-vs-string-literal.md
+++ b/docs/basic/string-slice-vs-string-literal.md
@@ -41,7 +41,7 @@ let str2 = String::from_utf8(bytes).unwrap();
 println!("str2: {}", str2);
 ```
 
-Pada contoh di atas, data bytes dipersiapkan dalam bentuk `Vec<u8>`. Data tersebut kemudian digunakan untuk membuat string menggunakan fungsi `String::from_utf8()`. Nilai balik fungsi tersebut adalah `Result<String, FromUtf8Error>`. Pemanggilan method `unwrap` disitu agar data `String`-nya di-return.
+Pada contoh di atas, data bytes dipersiapkan dalam bentuk `Vec<u8>`. Data tersebut kemudian digunakan untuk membuat string menggunakan fungsi `String::from_utf8()`. Nilai balik fungsi tersebut adalah `Result<String, FromUtf8Error>`. Pemanggilan method `unwrap` di situ agar data `String`-nya di-return.
 
 ![String slcie vs string literal](img/string-slice-vs-string-literal-1.png)
 

--- a/docs/basic/struct.md
+++ b/docs/basic/struct.md
@@ -48,7 +48,7 @@ Struct adalah *hanya definisi structure*-nya saja, struct tidak menampung nilai 
 
 > Notasi `Vec<String>` merupakan salah satu contoh penerapan generics. Topik ini nantinya dibahas lebih detail pada chapter [Generics](/basic/generics).
 
-Struct merupakan tipe data data custom, yang berarti tipe data tersebut bisa digunakan dalam pembuatan variabel. Sebagai contoh dibawah ini, sebuah variabel bernama `user_one` didefinisikan dengan tipe adalah struct `User` yang telah dibuat.
+Struct merupakan tipe data data custom, yang berarti tipe data tersebut bisa digunakan dalam pembuatan variabel. Sebagai contoh di bawah ini, sebuah variabel bernama `user_one` didefinisikan dengan tipe adalah struct `User` yang telah dibuat.
 
 ```rust
 struct User {
@@ -277,7 +277,7 @@ let car_five = Car{
 
 Cukup tulis nama variabelnya saja tanpa value.
 
-Teknik *shorthand* ini bisa juga digunakan dalam fungsi. Contoh dibawah ini ada fungsi bernama `new_car` yang memiliki nama parameter adalah sama persis dengan nama property struct `Car`.
+Teknik *shorthand* ini bisa juga digunakan dalam fungsi. Contoh di bawah ini ada fungsi bernama `new_car` yang memiliki nama parameter adalah sama persis dengan nama property struct `Car`.
 
 ```rust
 fn new_car(brand: String, model: String) -> Car {
@@ -311,7 +311,7 @@ let point_one = Point { x: 3.14, y: 8.0 };
 
 ### ◉ *Destructuring assignment*
 
-Teknik penulisan ini bisa dipakai dalam case dimana nilai property struct perlu ditampung ke variabel baru. Contoh:
+Teknik penulisan ini bisa dipakai dalam case di mana nilai property struct perlu ditampung ke variabel baru. Contoh:
 
 ```rust
 let point_one = Point { x: 3.14, y: 8.0 };
@@ -343,7 +343,7 @@ struct StructOne;
 let data_one = StructOne;
 ```
 
-Teknik pembuatan struct ini berguna ketika ada case dimana ada kebutuhan untuk mengimplementasikan sebuah trait ke suatu tipe data. Lebih jelasnya akan dibahas pada chapter [Traits](/basic/traits).
+Teknik pembuatan struct ini berguna ketika ada case di mana ada kebutuhan untuk mengimplementasikan sebuah trait ke suatu tipe data. Lebih jelasnya akan dibahas pada chapter [Traits](/basic/traits).
 
 ## A.23.6. Debugging value struct menggunakan `#[derive(Debug)]`
 

--- a/docs/basic/tipe-data-custom-type-string-slice.md
+++ b/docs/basic/tipe-data-custom-type-string-slice.md
@@ -101,7 +101,7 @@ println!("{str6}");
 // my phone is Pixel 6
 ```
 
-Parameter pertama perlu diisi dengan indeks di mana string akan disisipkan.
+Parameter pertama menentukan posisi indeks string yang disisipkan.
 
 - String `Pixel 6` pada indeks 0 disisipi string `my phone`, hasilnya `my phonePixel 6`
 - String `my phonePixel 6` pada indeks 8 disisipi string ` is `, hasilnya `my phone is Pixel 6`

--- a/docs/basic/tipe-data-custom-type-string-slice.md
+++ b/docs/basic/tipe-data-custom-type-string-slice.md
@@ -101,7 +101,7 @@ println!("{str6}");
 // my phone is Pixel 6
 ```
 
-Parameter pertama perlu diisi dengan indeks dimana string akan disisipkan.
+Parameter pertama perlu diisi dengan indeks di mana string akan disisipkan.
 
 - String `Pixel 6` pada indeks 0 disisipi string `my phone`, hasilnya `my phonePixel 6`
 - String `my phonePixel 6` pada indeks 8 disisipi string ` is `, hasilnya `my phone is Pixel 6`

--- a/docs/basic/tipe-data-primitive-scalar.md
+++ b/docs/basic/tipe-data-primitive-scalar.md
@@ -12,7 +12,7 @@ Tipe data scalar sendiri merupakan tipe data primitif yang isinya hanya 1 nilai.
 
 Signed integer merupakan tipe data numerik/integer yang bisa menampung nilai positif dan juga negatif. Ada beberapa tipe data singed integer tersedia di Rust yang dibedakan sesuai size-nya.
 
-Tipe data ini keyword-nya ditandai dengan huruf awalan `i`, contohnya `i8`, yang di mana tipe ini adalah tipe data numerik integer dengan range value yang bisa ditampung adalah mulai dari angka **−128** (didapat dari −(2<sup>7</sup>) hingga **127** (didapat dari 2<sup>7</sup>-1).
+Tipe data ini keyword-nya ditandai dengan huruf awalan `i`, contohnya `i8`, yang mana tipe ini adalah tipe data numerik integer dengan range value yang bisa ditampung adalah mulai dari angka **−128** (didapat dari −(2<sup>7</sup>) hingga **127** (didapat dari 2<sup>7</sup>-1).
 
 Contoh:
 
@@ -31,7 +31,7 @@ Range value pada tipe data itu cukup penting untuk diperhatikan, jika ada sebuah
 
 ![data type error](img/tipe-data-primitive-scalar-1.png)
 
-Umumnya, tipe data `i32` cukup untuk kebutuhan menampung nilai, tapi ada banyak case di mana kita perlu tipe dengan size yang lebih besar seperti `i64`.
+Umumnya, tipe data `i32` cukup digunakan untuk kebutuhan menampung nilai, namun sebenarnya ada banyak case lainnya di mana kita perlu tipe dengan size yang lebih besar seperti `i64`.
 
 Berikut merupakan list tipe data signed integers yang ada di Rust. Tidak perlu dihafal.
 

--- a/docs/basic/tipe-data-primitive-scalar.md
+++ b/docs/basic/tipe-data-primitive-scalar.md
@@ -12,7 +12,7 @@ Tipe data scalar sendiri merupakan tipe data primitif yang isinya hanya 1 nilai.
 
 Signed integer merupakan tipe data numerik/integer yang bisa menampung nilai positif dan juga negatif. Ada beberapa tipe data singed integer tersedia di Rust yang dibedakan sesuai size-nya.
 
-Tipe data ini keyword-nya ditandai dengan huruf awalan `i`, contohnya `i8`, yang dimana tipe ini adalah tipe data numerik integer dengan range value yang bisa ditampung adalah mulai dari angka **−128** (didapat dari −(2<sup>7</sup>) hingga **127** (didapat dari 2<sup>7</sup>-1).
+Tipe data ini keyword-nya ditandai dengan huruf awalan `i`, contohnya `i8`, yang di mana tipe ini adalah tipe data numerik integer dengan range value yang bisa ditampung adalah mulai dari angka **−128** (didapat dari −(2<sup>7</sup>) hingga **127** (didapat dari 2<sup>7</sup>-1).
 
 Contoh:
 
@@ -31,7 +31,7 @@ Range value pada tipe data itu cukup penting untuk diperhatikan, jika ada sebuah
 
 ![data type error](img/tipe-data-primitive-scalar-1.png)
 
-Umumnya, tipe data `i32` cukup untuk kebutuhan menampung nilai, tapi ada banyak case dimana kita perlu tipe dengan size yang lebih besar seperti `i64`.
+Umumnya, tipe data `i32` cukup untuk kebutuhan menampung nilai, tapi ada banyak case di mana kita perlu tipe dengan size yang lebih besar seperti `i64`.
 
 Berikut merupakan list tipe data signed integers yang ada di Rust. Tidak perlu dihafal.
 
@@ -106,7 +106,7 @@ Catatan saja, variabel yang dideklarasikan dengan predefined value adalah numeri
 
 ## A.5.3. Floating point
 
-Floating point adalah tipe data yang mendukung nilai dibelakang koma, contohnya seperti `3.14`. Di Rust ada dua tipe data floating point, yaitu `f34` dan `f64`. Contoh penggunaan:
+Floating point adalah tipe data yang mendukung nilai dibelakang koma, contohnya seperti `3.14`. Di Rust ada dua tipe data floating point, yaitu `f32` dan `f64`. Contoh penggunaan:
 
 ```rust
 let fp1: f32 = 3.14;

--- a/docs/basic/tipe-data-string-literal.md
+++ b/docs/basic/tipe-data-string-literal.md
@@ -91,7 +91,7 @@ let var5 = r#"
 println!("{}", var5);
 ```
 
-Kode di atas hasilnya adalah ekuivalen dengan kode dibawah ini, yang dimana string didefinisikan dengan meng-escape karakter `"` menggunakan `\`.
+Kode di atas hasilnya adalah ekuivalen dengan kode di bawah ini, yang di mana string didefinisikan dengan meng-escape karakter `"` menggunakan `\`.
 
 ```rust
 let var6 = "

--- a/docs/basic/tipe-data-string-literal.md
+++ b/docs/basic/tipe-data-string-literal.md
@@ -91,7 +91,7 @@ let var5 = r#"
 println!("{}", var5);
 ```
 
-Kode di atas hasilnya adalah ekuivalen dengan kode di bawah ini, yang di mana string didefinisikan dengan meng-escape karakter `"` menggunakan `\`.
+Kode di atas hasilnya adalah ekuivalen dengan kode di bawah ini, yang mana string didefinisikan dengan meng-escape karakter `"` menggunakan `\`.
 
 ```rust
 let var6 = "

--- a/docs/basic/trait-function.md
+++ b/docs/basic/trait-function.md
@@ -79,7 +79,7 @@ Jika dipaksa deklarasi menggunakan `Fn`, hasilnya pasti error.
 
 ![Closure](img/trait-function-1.png)
 
-`FnMut` merupakan supertrait dari `Fn`, artinya closure dengan trait `Fn` juga bisa digunakan sebagai argument pemanggilan fungsi dimana parameter fungsi tersebut bertipe `FnMut`.
+`FnMut` merupakan supertrait dari `Fn`, artinya closure dengan trait `Fn` juga bisa digunakan sebagai argument pemanggilan fungsi di mana parameter fungsi tersebut bertipe `FnMut`.
 
 > Lebih jelasnya mengenai supertrait dibahas pada chpater [Supertrait](#/wip/supertrait)
 

--- a/docs/basic/trait-iterator.md
+++ b/docs/basic/trait-iterator.md
@@ -256,7 +256,7 @@ println!("{:?}", result2);
 // [1, 2, 3, 4]
 ```
 
-Contoh lainnya bisa dilihat pada *section* [A.48.2. Pemanfaatan tipe data `Iterator`](/basic/trait-iterator#a482-pemanfaatan-tipe-data-iterator) di mana dilakukan mapping data slice numerik ke bentuk yang sama tapi nilai setiap element adalah kuadrat, dan juga ke bentuk lain dengan tipe data berbeda.
+Contoh lainnya bisa dilihat pada *section* [A.48.2. Pemanfaatan tipe data `Iterator`](/basic/trait-iterator#a482-pemanfaatan-tipe-data-iterator), di situ terdapat operasi mapping data slice numerik ke bentuk yang sama tapi nilai setiap element adalah kuadrat, dan ke bentuk lain dengan tipe data berbeda.
 
 ### ◉ Method `rev`
 

--- a/docs/basic/trait-iterator.md
+++ b/docs/basic/trait-iterator.md
@@ -10,7 +10,7 @@ Iterator adalah salah satu trait dan tipe data custom penting pada Rust programm
 
 `Iterator` adalah sebuah nama yang dipakai sebagai nama module item dalam **Rust Standard Library** maupun **Rust Core Library**, digunakan untuk iterasi data dan operasi lain yang berhubungan dengannya.
 
-Iterator sendiri merupakan istilah untuk object atau trait yang bisa diiterasi, baik menggunakan keyword `for in` ataupun menggunakan method iterator seperti `for_each` (yang juga akan kita bahas disini).
+Iterator sendiri merupakan istilah untuk object atau trait yang bisa diiterasi, baik menggunakan keyword `for in` ataupun menggunakan method iterator seperti `for_each` (yang juga akan kita bahas di sini).
 
 ### ◉ Trait `Iterator` & `IntoIterator`
 
@@ -256,7 +256,7 @@ println!("{:?}", result2);
 // [1, 2, 3, 4]
 ```
 
-Contoh lainnya bisa dilihat pada *section* [A.48.2. Pemanfaatan tipe data `Iterator`](/basic/trait-iterator#a482-pemanfaatan-tipe-data-iterator) dimana dilakukan mapping data slice numerik ke bentuk yang sama tapi nilai setiap element adalah kuadrat, dan juga ke bentuk lain dengan tipe data berbeda.
+Contoh lainnya bisa dilihat pada *section* [A.48.2. Pemanfaatan tipe data `Iterator`](/basic/trait-iterator#a482-pemanfaatan-tipe-data-iterator) di mana dilakukan mapping data slice numerik ke bentuk yang sama tapi nilai setiap element adalah kuadrat, dan juga ke bentuk lain dengan tipe data berbeda.
 
 ### ◉ Method `rev`
 

--- a/docs/basic/traits.md
+++ b/docs/basic/traits.md
@@ -121,7 +121,7 @@ Block kode definisi struct `Circle` cukup straightforward, isinya hanya 1 proper
 
 ### ◉ Block kode `impl X for Y`
 
-Notasi penulisan implementasi trait adalah `impl X for Y`, dimana `X` adalah trait yang ingin diimplementasikan dan `Y` adalah tipe data tujuan implementasi.
+Notasi penulisan implementasi trait adalah `impl X for Y`, di mana `X` adalah trait yang ingin diimplementasikan dan `Y` adalah tipe data tujuan implementasi.
 
 Pada contoh di atas, trait `Debug` diimplementasikan ke custom type struct `Circle`. Maka statement-nya adalah:
 
@@ -157,7 +157,7 @@ impl std::fmt::Debug for Circle {
 }
 ```
 
-> Tips untuk pengguna visual studio code dengan rust-analyzer extension ter-install, setelah selesai menulis block kode `impl`, cukup jalankan `ctrl+space` atau `cmd+space` untuk men-trigger autocomplete suggestion. Kemudian klik opsi method yang ada disitu, maka kode implementasi method langsung muncul dengan sendirinya.
+> Tips untuk pengguna visual studio code dengan rust-analyzer extension ter-install, setelah selesai menulis block kode `impl`, cukup jalankan `ctrl+space` atau `cmd+space` untuk men-trigger autocomplete suggestion. Kemudian klik opsi method yang ada di situ, maka kode implementasi method langsung muncul dengan sendirinya.
 
 ### ◉ Macro `write`
 
@@ -482,7 +482,7 @@ Tipe data aslinya tetap bisa diakses, tapi butuh tambahan effort. Lebih jelasnya
 
 ## A.36.8. *Associated types* pada trait
 
-Associated types adalah tipe data yang didefinisikan didalam suatu trait. Associated types tidak tidak memiliki tipe data konkret saat didefinisikan, namun ketika trait di-implementasikan maka tipe tersebut harus ditentukan tipe data konkritnya.
+Associated types adalah tipe data yang didefinisikan di dalam suatu trait. Associated types tidak tidak memiliki tipe data konkret saat didefinisikan, namun ketika trait di-implementasikan maka tipe tersebut harus ditentukan tipe data konkritnya.
 
 Lebih jelas silakan perhatikan kode berikut:
 

--- a/docs/basic/traits.md
+++ b/docs/basic/traits.md
@@ -121,7 +121,7 @@ Block kode definisi struct `Circle` cukup straightforward, isinya hanya 1 proper
 
 ### ◉ Block kode `impl X for Y`
 
-Notasi penulisan implementasi trait adalah `impl X for Y`, di mana `X` adalah trait yang ingin diimplementasikan dan `Y` adalah tipe data tujuan implementasi.
+Notasi penulisan implementasi trait adalah `impl X for Y`, yang mana `X` adalah trait yang ingin diimplementasikan dan `Y` adalah tipe data tujuan implementasi.
 
 Pada contoh di atas, trait `Debug` diimplementasikan ke custom type struct `Circle`. Maka statement-nya adalah:
 

--- a/docs/basic/tuple.md
+++ b/docs/basic/tuple.md
@@ -23,7 +23,7 @@ println!("tuple_a: {:?}", tuple_a);
 
 Variabel `tuple_a` di atas bertipe data tuple, dengan tipe data spesifik per-elemennya bervariasi, ada string, numerik, array `[&str; 2]`, dan boolean.
 
-Untuk menampilkan nilai per-elemen, gunakan notasi `.N` dimana `N` merupakan indeks elemen. Contohnya seperti berikut:
+Untuk menampilkan nilai per-elemen, gunakan notasi `.N` di mana `N` merupakan indeks elemen. Contohnya seperti berikut:
 
 ```rust
 println!("index 0: {:?}", tuple_a.0);
@@ -90,7 +90,7 @@ tuple_b.3 = true;
 
 ### ◉ Packing tuple
 
-Adalah cara pembuatan tuple yang dimana nilai elemenya bersumber dari variabel lain.
+Adalah cara pembuatan tuple yang di mana nilai elemenya bersumber dari variabel lain.
 
 ```rust
 let name = "grayson";

--- a/docs/basic/tuple.md
+++ b/docs/basic/tuple.md
@@ -23,7 +23,7 @@ println!("tuple_a: {:?}", tuple_a);
 
 Variabel `tuple_a` di atas bertipe data tuple, dengan tipe data spesifik per-elemennya bervariasi, ada string, numerik, array `[&str; 2]`, dan boolean.
 
-Untuk menampilkan nilai per-elemen, gunakan notasi `.N` di mana `N` merupakan indeks elemen. Contohnya seperti berikut:
+Untuk menampilkan nilai per-elemen, gunakan notasi `.N` yang mana `N` merupakan indeks elemen. Contohnya seperti berikut:
 
 ```rust
 println!("index 0: {:?}", tuple_a.0);
@@ -90,7 +90,7 @@ tuple_b.3 = true;
 
 ### ◉ Packing tuple
 
-Adalah cara pembuatan tuple yang di mana nilai elemenya bersumber dari variabel lain.
+Adalah cara pembuatan tuple yang mana nilai elemenya bersumber dari variabel lain.
 
 ```rust
 let name = "grayson";

--- a/docs/basic/use.md
+++ b/docs/basic/use.md
@@ -8,7 +8,7 @@ Keyword `use` digunakan untuk dua hal, yaitu *import* path dan *re-export* path.
 
 ## A.29.1. Keyword `use` untuk import path
 
-Untuk bisa menggunakan sebuah item dari crate lain, entah itu dari rust standard library crate maupun 3rd-party, caranya cukup dengan menuliskan path item. Contohnya bisa dilihat dibawah ini, fungsi `current_dir` digunakan untuk mengambil path dari current directory. Fungsi tersebut merupakan item dari module `std::env`, maka untuk mengaksesnya kita harus menuliskan path secara lengkap.
+Untuk bisa menggunakan sebuah item dari crate lain, entah itu dari rust standard library crate maupun 3rd-party, caranya cukup dengan menuliskan path item. Contohnya bisa dilihat di bawah ini, fungsi `current_dir` digunakan untuk mengambil path dari current directory. Fungsi tersebut merupakan item dari module `std::env`, maka untuk mengaksesnya kita harus menuliskan path secara lengkap.
 
 ```rust
 let package_path = std::env::current_dir().unwrap();
@@ -86,7 +86,7 @@ Bisa dilihat pada gambar berikut, jika ada argument disisipkan dalam eksekusi pr
 
 Re-export item adalah sebuah cara untuk mem-*bypass* pengaksesan item yang secara hirarki memang tidak bisa diakses dari luar module (bisa jadi karena visibility item ataupun parent module nya adalah private). Dengan teknik ini, maka item pasti bisa diakses dari luar module.
 
-Item yang di-re-export akan menjadi item milik *current module* dimana statement re-export tersebut ditulis.
+Item yang di-re-export akan menjadi item milik *current module* di mana statement re-export tersebut ditulis.
 
 Keyword `pub use` digunakan untuk operasi re-export. Notasi penulisannya bisa dilihat di bawah ini:
 

--- a/docs/basic/variabel.md
+++ b/docs/basic/variabel.md
@@ -19,7 +19,7 @@ fn main() {
 }
 ```
 
-Ok, sekarang coba jalankan, dan lanjut ke pembahasan dibawah.
+Ok, sekarang coba jalankan, dan lanjut ke pembahasan di bawah.
 
 ### ◉ Aturan penamaan variabel (naming convention)
 
@@ -138,7 +138,7 @@ println!("message number {1}: {0}", message3, message_number);
 
 ![formatted print macro `println`](img/variabel-6.png)
 
-Jika dilihat ada yg berbeda pada cara deklarasi variabel `message3` dan juga pada statement `println` untuk `message3` yang disitu digunakan `{1}` dan `{0}`, tidak seperti sebelumnya yg menggunakan `{}`. Kita akan bahas yg ke-2 terlebih dahulu.
+Jika dilihat ada yg berbeda pada cara deklarasi variabel `message3` dan juga pada statement `println` untuk `message3` yang di situ digunakan `{1}` dan `{0}`, tidak seperti sebelumnya yg menggunakan `{}`. Kita akan bahas yg ke-2 terlebih dahulu.
 
 - Jika menggunakan `{}`, maka string akan di-replace sesuai urutan argument pada pemanggilan `println`.
 - Jika menggunakan `{0}`, maka string akan di-replace dengan data pada argument ke `1` pemanggilan fungsi `println`, yang pada contoh di atas adalah `message3`.
@@ -153,7 +153,7 @@ println!("message number {0}: {1}", message_number, message3);
 println!("message number {1}: {0}", message3, message_number);
 ```
 
-Sekarang perihal perbedaan cara deklarasi `message3` akan kita bahas dibawah ini.
+Sekarang perihal perbedaan cara deklarasi `message3` akan kita bahas di bawah ini.
 
 ## A.4.4. *Type Inference* vs *Manifest Typing*
 

--- a/docs/basic/vector.md
+++ b/docs/basic/vector.md
@@ -18,7 +18,7 @@ Vector bisa bertambah jumlah isinya selama size di bawah kapasitas yang sudah di
 
 ## A.16.1. Tipe data `Vec<T>`
 
-`Vec<T>` adalah tipe data yang merepresentasikan vector, di mana `T` adalah generics. Vector datanya dialokasikan di heap memory.
+`Vec<T>` adalah tipe data yang merepresentasikan vector, yang mana `T` adalah generics. Vector datanya dialokasikan di heap memory.
 
 > - Lebih jelasnya mengenai generic dibahas pada chapter [Generics](/basic/generics)
 > - Lebih jelasnya mengenai heap dibahas pada chapter [Basic Memory Management](/basic/basic-memory-management)
@@ -108,7 +108,7 @@ Bisa dilihat sekarang `data_one` isinya adalah 4 elemen dan atribut size-nya coc
 
 Perubahan kapasitas atau realokasi vector terjadi ketika sebuah vector isinya bertambah lebih banyak dari jumlah alokasi maksimal kapasitas.
 
-Lalu apa efeknya? secara high level bisa dibilang tidak ada, namun kalau dibahas lebih rinci, efeknya adalah di sisi alokasi space untuk menampung elemen. Terjadi proses realokasi di mana vector yang baru akan memiliki kapasitas lebih besar.
+Lalu apa efeknya? secara high level bisa dibilang tidak ada, namun kalau dibahas lebih rinci, efeknya adalah di sisi alokasi space untuk menampung elemen. Proses realokasi menghasilkan vector yang baru dengan kapasitas lebih besar.
 
 ### ◉ Mengubah value sebuah elemen menggunakan notasi `[i]`
 
@@ -338,7 +338,7 @@ println!("data: {:?}", vec_10);
 
 ![Vector](img/vector-12.png)
 
-Tipe data `VecDeque<T>` tidak otomatis di-import. Kita perlu mengimport path di mana tipe data itu berada menggunakan keyword `use`.
+Tipe data `VecDeque<T>` tidak otomatis di-import. Kita perlu mengimport path di mana tipe data tersebut berada menggunakan keyword `use`.
 
 ```rust
 use std::collections::VecDeque;

--- a/docs/basic/vector.md
+++ b/docs/basic/vector.md
@@ -14,11 +14,11 @@ Vector memiliki 3 buah atribut yg penting untuk diketahui:
 - lebar atau size
 - kapasitas (representasi dari seberapa banyak memori di-booking untuk data vector tersebut)
 
-Vector bisa bertambah jumlah isinya selama size dibawah kapasitas yang sudah dialokasikan. Jika suatu ketika vector isinya bertambah lebih banyak dari jumlah alokasi maksimal kapasitas, maka vector akan dialokasikan ulang dengan kapasitas yang lebih besar.
+Vector bisa bertambah jumlah isinya selama size di bawah kapasitas yang sudah dialokasikan. Jika suatu ketika vector isinya bertambah lebih banyak dari jumlah alokasi maksimal kapasitas, maka vector akan dialokasikan ulang dengan kapasitas yang lebih besar.
 
 ## A.16.1. Tipe data `Vec<T>`
 
-`Vec<T>` adalah tipe data yang merepresentasikan vector, dimana `T` adalah generics. Vector datanya dialokasikan di heap memory.
+`Vec<T>` adalah tipe data yang merepresentasikan vector, di mana `T` adalah generics. Vector datanya dialokasikan di heap memory.
 
 > - Lebih jelasnya mengenai generic dibahas pada chapter [Generics](/basic/generics)
 > - Lebih jelasnya mengenai heap dibahas pada chapter [Basic Memory Management](/basic/basic-memory-management)
@@ -108,7 +108,7 @@ Bisa dilihat sekarang `data_one` isinya adalah 4 elemen dan atribut size-nya coc
 
 Perubahan kapasitas atau realokasi vector terjadi ketika sebuah vector isinya bertambah lebih banyak dari jumlah alokasi maksimal kapasitas.
 
-Lalu apa efeknya? secara high level bisa dibilang tidak ada, namun kalau dibahas lebih rinci, efeknya adalah di sisi alokasi space untuk menampung elemen. Terjadi proses realokasi dimana vector yang baru akan memiliki kapasitas lebih besar.
+Lalu apa efeknya? secara high level bisa dibilang tidak ada, namun kalau dibahas lebih rinci, efeknya adalah di sisi alokasi space untuk menampung elemen. Terjadi proses realokasi di mana vector yang baru akan memiliki kapasitas lebih besar.
 
 ### ◉ Mengubah value sebuah elemen menggunakan notasi `[i]`
 
@@ -338,7 +338,7 @@ println!("data: {:?}", vec_10);
 
 ![Vector](img/vector-12.png)
 
-Tipe data `VecDeque<T>` tidak otomatis di-import. Kita perlu mengimport path dimana tipe data itu berada menggunakan keyword `use`.
+Tipe data `VecDeque<T>` tidak otomatis di-import. Kita perlu mengimport path di mana tipe data itu berada menggunakan keyword `use`.
 
 ```rust
 use std::collections::VecDeque;

--- a/docs/basic/visibility-privacy.md
+++ b/docs/basic/visibility-privacy.md
@@ -27,7 +27,7 @@ Di Rust, *by default*, hampir semua item adalah private. Apa efeknya ketika item
 1. Jika suatu item adalah private, maka item tersebut hanya bisa diakses dari *current module scope* dan dari *submodules* milik *current module*.
 2. Jika suatu item adalah publik, maka dia bisa diakses dari module lain di luar *current module scope*, dengan catatan parent module scope item tersebut harus publik.
 
-> Kita sepakati di sini, pada istilah **current module** kata *module* disitu bisa saja tertuju untuk module atau juga submodule
+> Kita sepakati di sini, pada istilah **current module** kata *module* di situ bisa saja tertuju untuk module atau juga submodule
 
 Dua point di atas sangat penting untuk dipahami, karena digunakan sebagai landasan pertimbangan dalam penyusunan hirarki module. Sebagai contoh, kita bisa membuat program yang hanya meng-expose API tertentu (yang memang diperlukan untuk diakses oleh publik), tanpa perlu ikut meng-expose detail implementasinya.
 
@@ -39,7 +39,7 @@ messaging::service_layer::some_black_magic
 
 Segmen pertama yaitu `messaging` pasti adalah publik, karena di-import ke *crate root*. Lalu bagaimana dengan segmen `service_layer` dan juga `some_black_magic`?
 
-Jika item `some_black_magic` disitu adalah publik, maka idealnya pengaksesan menggunakan path tersebut memungkinkan. Tapi kembali ke point ke-2 aturan yang sudah dibahas di atas, yaitu meskipun `some_black_magic` adalah publik, jika parent-nya (yang pada konteks ini adalah `service_layer`) adalah private, maka pengaksesan menggunakan path tersebut menghasilkan error.
+Jika item `some_black_magic` di situ adalah publik, maka idealnya pengaksesan menggunakan path tersebut memungkinkan. Tapi kembali ke point ke-2 aturan yang sudah dibahas di atas, yaitu meskipun `some_black_magic` adalah publik, jika parent-nya (yang pada konteks ini adalah `service_layer`) adalah private, maka pengaksesan menggunakan path tersebut menghasilkan error.
 
 Intinya, **sebuah item bisa diakses jika item tersebut adalah publik, dan parent item tersebut juga publik. Sedangkan default visibility untuk hampir semua item adalah private.**
 
@@ -80,13 +80,13 @@ fn main() {
 
   - Konstanta ini merupakan module item milik `messaging`.
   - Konstanta ini **bisa diakses** dari *current module scope* (`messaging`).
-  - Konstanta ini **bisa diakses** dari submodule milik *current module*, yaitu submodule dari `messaging`. Contohnya bisa dilihat pada fungsi `messaging::service_layer::some_black_magic` yang disitu ada statement pemanggilan `SOME_MESSAGE`.
+  - Konstanta ini **bisa diakses** dari submodule milik *current module*, yaitu submodule dari `messaging`. Contohnya bisa dilihat pada fungsi `messaging::service_layer::some_black_magic` yang di situ ada statement pemanggilan `SOME_MESSAGE`.
   - Konstanta ini **tidak bisa diakses** dari luar *current module scope* (`messaging`).
 
 - Submodule `messaging::service_layer` adalah **private**. Penjelasan:
 
   - Submodule ini merupakan module item milik `messaging`.
-  - Submodule ini **bisa diakses** dari *current module scope* (`messaging`). Contohnya bisa dilihat pada fungsi `messaging::say_hello` yang disitu ada statement pemanggilan `service_layer`.
+  - Submodule ini **bisa diakses** dari *current module scope* (`messaging`). Contohnya bisa dilihat pada fungsi `messaging::say_hello` yang di situ ada statement pemanggilan `service_layer`.
   - Submodule ini **bisa diakses** dari submodule milik *current module*, yaitu submodule dari `messaging`.
   - Submodule ini **tidak bisa diakses** dari luar *current module scope* (`messaging`).
 
@@ -94,7 +94,7 @@ fn main() {
 
   - Fungsi ini merupakan module item milik `messaging::service_layer`.
   - Fungsi ini **bisa diakses** dari *current module scope* (`messaging::service_layer`).
-  - Fungsi ini **bisa diakses** dari submodule milik *current module*, yaitu submodule dari `messaging::service_layer`. Contohnya bisa dilihat pada fungsi `messaging::say_hello` yang disitu ada statement pemanggilan fungsi `some_black_magic`.
+  - Fungsi ini **bisa diakses** dari submodule milik *current module*, yaitu submodule dari `messaging::service_layer`. Contohnya bisa dilihat pada fungsi `messaging::say_hello` yang di situ ada statement pemanggilan fungsi `some_black_magic`.
   - Fungsi ini **bisa diakses** dari luar *current module scope* (`messaging::service_layer`).
   - Namun meskipun demikian, bisa tidaknya fungsi ini diakses dari luar *current module scope* (`messaging::service_layer`) juga tergantung dengan visibility dari current module itu sendiri, yaitu `messaging::service_layer`.
   - Karena module `messaging::service_layer` adalah private, meskipun fungsi `some_black_magic` di dalamnya adalah publik, pengaksesan fungsi tersebut dari luar module scope `messaging::service_layer` tidak dimungkinkan.
@@ -106,7 +106,7 @@ fn main() {
   - Fungsi ini merupakan module item milik `messaging`.
   - Fungsi ini **bisa diakses** dari *current module scope* (`messaging`).
   - Fungsi ini **bisa diakses** dari submodule milik *current module*, yaitu submodule dari `messaging`.
-  - Fungsi ini **bisa diakses** dari luar *current module scope* (`messaging`). Contohnya bisa dilihat pada crate root fungsi `main`, disitu ada pemanggilan statement `say_hello`.
+  - Fungsi ini **bisa diakses** dari luar *current module scope* (`messaging`). Contohnya bisa dilihat pada crate root fungsi `main`, di situ ada pemanggilan statement `say_hello`.
 
 ## A.28.3. Re-export item
 
@@ -120,7 +120,7 @@ Pada praktik selanjutnya ini kita misalkan bahwa fungsi `say_hello` isinya meman
 
 Re-export item adalah sebuah cara untuk mem-*bypass* pengaksesan item yang secara hirarki memang tidak bisa diakses dari luar module (bisa jadi karena visibility item ataupun parent module nya adalah private). Dengan teknik ini, maka item pasti bisa diakses dari luar module.
 
-Item yang di-re-export akan menjadi item milik *current module* dimana statement re-export tersebut ditulis.
+Item yang di-re-export akan menjadi item milik *current module* di mana statement re-export tersebut ditulis.
 
 Cara re-export item adalah menggunakan keyword `pub use` kemudian diikuti dengan path yang ingin di-export dan juga nama export item dengan notasi penulisan berikut:
 
@@ -200,7 +200,7 @@ Dengan keyword `pub`, sebuah item visibility-nya menjadi publik.
 
 ### ◉ Keyword `pub(in path)`
 
-Keyword ini menjadikan visibility item hanya di dalam `path` yang ditulis di `pub(in path)`, dengan ketentuan `path` tersebut merupakan parent dari module item dimana keyword digunakan.
+Keyword ini menjadikan visibility item hanya di dalam `path` yang ditulis di `pub(in path)`, dengan ketentuan `path` tersebut merupakan parent dari module item di mana keyword digunakan.
 
 Contohnya bisa dilihat pada kode berikut. Fungsi `say_hello` didefinisikan publik dengan scope path ditentukan secara eksplisit adalah `crate::outer_mod`. Dengan demikian fungsi `say_hello` hanya bisa diakses dari dalam `outer_mod`.
 

--- a/docs/pengelanan-rust-programming.md
+++ b/docs/pengelanan-rust-programming.md
@@ -6,7 +6,7 @@ sidebar_label: Pengenalan Rust Programming
 
 Rust adalah sebuah bahasa pemrograman general purpose yang fokus pada performance, type safety, dan concurrency. Bahasa ini diciptakan sebagai alternatif bahasa pemrograman yang berfokus pada hal-hal yang cukup low-level tapi tetap men-support fitur yang sifatnya high-level.
 
-Rust dikembangkan oleh [Graydon Hoare](https://twitter.com/graydon_pub) sewaktu ia masih bekerja di Mozilla pada tahun 2009, kemudian di-maintain dibawah naungan Rust Foundation hingga sekarang.
+Rust dikembangkan oleh [Graydon Hoare](https://twitter.com/graydon_pub) sewaktu ia masih bekerja di Mozilla pada tahun 2009, kemudian di-maintain di bawah naungan Rust Foundation hingga sekarang.
 
 Rust memiliki beberapa kelebihan dibanding bahasa system-programming lainnya, yang di antaranya adalah:
 


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fix issues #87 

**Checklist:**
- [X] `f34` -> `f32`
- [X] pada chapter [Pointer & References](/basic/pointer-references#a315-karakteristik-pointer--reference) chapter ini -> pada chapter [Pointer & References](/basic/pointer-references#a315-karakteristik-pointer--reference) ini 
- [X] murapakan -> merupakan
- [X] ...hasilnya bisa dilihat digambar dibawahnya... ->  ..hasilnya bisa dilihat pada gambar di bawahnya...
- [X] data primitif jenis scalas -> data primitif jenis scalar
- [X] `[[&str; 2] 3]` -> `[[&str; 2]; 3]`
- [X] dimabil -> diambil
- [X] disitu -> di situ
- [X] dibawah -> di bawah
- [X] dimana -> di mana
- [X] disana -> di sana
- [X] diantara -> di antara
- [X] didalam -> di dalam
- [X] disini -> di sini